### PR TITLE
Add chapter editing and Audnexus lookup

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
@@ -84,6 +84,20 @@ interface SapphoApi {
     @GET("api/audiobooks/{id}/chapters")
     suspend fun getChapters(@Path("id") audiobookId: Int): Response<List<Chapter>>
 
+    // Update Chapter Titles (Admin)
+    @PUT("api/audiobooks/{id}/chapters")
+    suspend fun updateChapters(
+        @Path("id") audiobookId: Int,
+        @Body request: ChapterUpdateRequest
+    ): Response<ChapterUpdateResponse>
+
+    // Fetch Chapters from Audnexus by ASIN (Admin)
+    @POST("api/audiobooks/{id}/fetch-chapters")
+    suspend fun fetchChapters(
+        @Path("id") audiobookId: Int,
+        @Body request: FetchChaptersRequest
+    ): Response<FetchChaptersResponse>
+
     // Files
     @GET("api/audiobooks/{id}/files")
     suspend fun getFiles(@Path("id") audiobookId: Int): Response<List<AudiobookFile>>
@@ -816,5 +830,29 @@ data class MetadataSearchResult(
     val tags: String?,
     val rating: Float?,
     val image: String?,
-    val language: String?
+    val language: String?,
+    val hasChapters: Boolean?
+)
+
+// Chapter Update Data Classes
+data class ChapterUpdate(
+    val id: Int,
+    val title: String
+)
+
+data class ChapterUpdateRequest(
+    val chapters: List<ChapterUpdate>
+)
+
+data class ChapterUpdateResponse(
+    val message: String?
+)
+
+data class FetchChaptersRequest(
+    val asin: String
+)
+
+data class FetchChaptersResponse(
+    val message: String?,
+    val chapters: List<com.sappho.audiobooks.domain.model.Chapter>?
 )

--- a/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
+++ b/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
@@ -105,9 +105,9 @@ object NetworkModule {
                 }
                 response
             }
-            .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(30, TimeUnit.SECONDS)
-            .writeTimeout(30, TimeUnit.SECONDS)
+            .connectTimeout(60, TimeUnit.SECONDS)
+            .readTimeout(60, TimeUnit.SECONDS)
+            .writeTimeout(60, TimeUnit.SECONDS)
             .build()
     }
 

--- a/app/src/main/java/com/sappho/audiobooks/domain/model/Audiobook.kt
+++ b/app/src/main/java/com/sappho/audiobooks/domain/model/Audiobook.kt
@@ -13,6 +13,7 @@ data class Audiobook(
     val genre: String?,
     @SerializedName("published_year") val publishYear: Int?,
     val isbn: String?,
+    val asin: String?,
     val description: String?,
     @SerializedName("cover_image") val coverImage: String?,
     @SerializedName("file_count") val fileCount: Int,


### PR DESCRIPTION
## Summary
- Add chapter editing dialog with edit mode toggle for updating chapter titles
- Add Audnexus chapter lookup by ASIN from both chapters dialog and metadata edit dialog
- Auto-close metadata dialog on successful save/embed with success message
- Improve embed metadata error handling with better server error messages
- Increase network timeouts from 30s to 60s for long operations

## Test plan
- [ ] Open a book detail, tap chapters button, verify chapters display
- [ ] Toggle edit mode, modify chapter titles, save changes
- [ ] Enter ASIN in chapters dialog and fetch chapters from Audnexus
- [ ] In metadata edit, select an Audible result with chapters, tap "Chapters" button
- [ ] Save metadata and verify dialog closes with success message
- [ ] Save & Embed and verify dialog closes after embedding completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)