### PR TITLE
Add version display in dropdown and fix slider seek behavior

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,6 +47,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     composeOptions {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/main/MainScreen.kt
@@ -44,6 +44,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.sappho.audiobooks.R
+import com.sappho.audiobooks.BuildConfig
 import com.sappho.audiobooks.presentation.home.HomeScreen
 import com.sappho.audiobooks.domain.model.User
 import com.sappho.audiobooks.presentation.library.LibraryScreen
@@ -108,6 +109,7 @@ fun MainScreen(
     var showUserMenu by remember { mutableStateOf(false) }
     val user by viewModel.user.collectAsState()
     val serverUrl by viewModel.serverUrl.collectAsState()
+    val serverVersion by viewModel.serverVersion.collectAsState()
     val currentAudiobook by viewModel.playerState.currentAudiobook.collectAsState()
     val context = androidx.compose.ui.platform.LocalContext.current
 
@@ -124,6 +126,7 @@ fun MainScreen(
                 navController = navController,
                 user = user,
                 serverUrl = serverUrl,
+                serverVersion = serverVersion,
                 showUserMenu = showUserMenu,
                 onUserMenuToggle = { showUserMenu = !showUserMenu },
                 onProfileClick = {
@@ -528,6 +531,7 @@ fun TopBar(
     navController: NavHostController,
     user: User?,
     serverUrl: String?,
+    serverVersion: String?,
     showUserMenu: Boolean,
     onUserMenuToggle: () -> Unit,
     onProfileClick: () -> Unit,
@@ -540,6 +544,7 @@ fun TopBar(
     onDownloadsClick: () -> Unit,
     downloadCount: Int
 ) {
+    val appVersion = BuildConfig.VERSION_NAME
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
 
@@ -687,6 +692,29 @@ fun TopBar(
                         text = "Logout",
                         onClick = onLogout
                     )
+
+                    // Version info at the bottom
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = 4.dp)
+                    ) {
+                        Column {
+                            Text(
+                                text = "App v$appVersion",
+                                color = Color(0xFF6b7280),
+                                fontSize = 11.sp
+                            )
+                            if (serverVersion != null) {
+                                Text(
+                                    text = "Server v$serverVersion",
+                                    color = Color(0xFF6b7280),
+                                    fontSize = 11.sp
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/main/MainViewModel.kt
@@ -25,10 +25,14 @@ class MainViewModel @Inject constructor(
     private val _serverUrl = MutableStateFlow<String?>(null)
     val serverUrl: StateFlow<String?> = _serverUrl
 
+    private val _serverVersion = MutableStateFlow<String?>(null)
+    val serverVersion: StateFlow<String?> = _serverVersion
+
     init {
         _serverUrl.value = authRepository.getServerUrlSync()
         loadCachedUser() // Load cached user first for immediate display
         loadUser()
+        loadServerVersion()
     }
 
     private fun loadCachedUser() {
@@ -66,6 +70,19 @@ class MainViewModel @Inject constructor(
             } catch (e: Exception) {
                 // Offline - keep using cached user
                 android.util.Log.e("MainViewModel", "Exception loading user (offline?)", e)
+            }
+        }
+    }
+
+    private fun loadServerVersion() {
+        viewModelScope.launch {
+            try {
+                val response = api.getHealth()
+                if (response.isSuccessful) {
+                    _serverVersion.value = response.body()?.version
+                }
+            } catch (e: Exception) {
+                // Ignore errors - version is optional
             }
         }
     }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
@@ -657,8 +657,8 @@ fun PlayerScreen(
                                 dragPosition = newValue
                             },
                             onValueChangeFinished = {
-                                // Only seek when user releases the slider
-                                AudioPlaybackService.instance?.seekTo(dragPosition.toLong())
+                                // Seek and start playing when user releases the slider
+                                AudioPlaybackService.instance?.seekToAndPlay(dragPosition.toLong())
                                 isDragging = false
                             },
                             valueRange = 0f..duration.toFloat().coerceAtLeast(1f),


### PR DESCRIPTION
## Summary
- Display app and server versions at bottom of profile dropdown menu
- Fix player slider to start playback when user releases after seeking (uses seekToAndPlay instead of seekTo)
- Enable BuildConfig generation to access VERSION_NAME

## Test plan
- [ ] Open app, tap profile icon, verify app version (v1.1.0) shows at bottom of dropdown
- [ ] Verify server version also appears below app version
- [ ] Open player, drag seek slider to new position and release - playback should start from that position

🤖 Generated with [Claude Code](https://claude.com/claude-code)