### PR TITLE
Add files dropdown and format field to book detail screen

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
@@ -98,9 +98,9 @@ interface SapphoApi {
         @Body request: FetchChaptersRequest
     ): Response<FetchChaptersResponse>
 
-    // Files
-    @GET("api/audiobooks/{id}/files")
-    suspend fun getFiles(@Path("id") audiobookId: Int): Response<List<AudiobookFile>>
+    // Directory Files
+    @GET("api/audiobooks/{id}/directory-files")
+    suspend fun getFiles(@Path("id") audiobookId: Int): Response<List<DirectoryFile>>
 
     // Delete
     @DELETE("api/audiobooks/{id}")

--- a/app/src/main/java/com/sappho/audiobooks/domain/model/Audiobook.kt
+++ b/app/src/main/java/com/sappho/audiobooks/domain/model/Audiobook.kt
@@ -61,6 +61,14 @@ data class AudiobookFile(
     val mimeType: String?
 )
 
+// Response from /api/audiobooks/{id}/directory-files endpoint
+data class DirectoryFile(
+    val name: String,
+    val path: String,
+    val size: Long,
+    val extension: String
+)
+
 data class AuthResponse(
     val token: String,
     val user: User

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
@@ -622,7 +622,7 @@ fun AudiobookDetailScreen(
                                                     .padding(12.dp)
                                             ) {
                                                 Text(
-                                                    text = file.filename,
+                                                    text = file.name,
                                                     color = Color(0xFFE0E7F1),
                                                     fontSize = 14.sp,
                                                     fontWeight = FontWeight.Medium
@@ -903,6 +903,14 @@ fun AudiobookDetailScreen(
                                 "${minutes}m"
                             }
                             MetadataItem("Duration", durationText)
+                        }
+
+                        // Format - derived from first file's extension
+                        files.firstOrNull()?.let { firstFile ->
+                            val format = firstFile.extension.removePrefix(".").uppercase()
+                            if (format.isNotEmpty()) {
+                                MetadataItem("Format", format)
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModel.kt
@@ -14,7 +14,7 @@ import com.sappho.audiobooks.data.remote.SapphoApi
 import com.sappho.audiobooks.data.remote.UserRating
 import com.sappho.audiobooks.data.repository.AuthRepository
 import com.sappho.audiobooks.domain.model.Audiobook
-import com.sappho.audiobooks.domain.model.AudiobookFile
+import com.sappho.audiobooks.domain.model.DirectoryFile
 import com.sappho.audiobooks.domain.model.Chapter
 import com.sappho.audiobooks.domain.model.Progress
 import com.sappho.audiobooks.service.DownloadService
@@ -48,8 +48,8 @@ class AudiobookDetailViewModel @Inject constructor(
     private val _chapters = MutableStateFlow<List<Chapter>>(emptyList())
     val chapters: StateFlow<List<Chapter>> = _chapters
 
-    private val _files = MutableStateFlow<List<AudiobookFile>>(emptyList())
-    val files: StateFlow<List<AudiobookFile>> = _files
+    private val _files = MutableStateFlow<List<DirectoryFile>>(emptyList())
+    val files: StateFlow<List<DirectoryFile>> = _files
 
     private val _serverUrl = MutableStateFlow<String?>(null)
     val serverUrl: StateFlow<String?> = _serverUrl


### PR DESCRIPTION
## Summary
- Fix directory-files API endpoint (was using non-existent `/files` endpoint, now correctly uses `/directory-files`)
- Add `DirectoryFile` model matching server response (`name`, `path`, `size`, `extension`)
- Display Format metadata field (e.g., "M4B", "MP3") derived from file extension
- Files dropdown now properly shows file names and sizes like the PWA

Closes #44

## Test plan
- [ ] Open a book detail screen
- [ ] Verify the Format field appears in the metadata section (below Duration)
- [ ] Verify the Files dropdown appears and can be expanded
- [ ] Verify files show names and sizes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)