### PR TITLE
Harden CI workflow security for public repo

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,16 +14,21 @@ on:
         required: false
         type: string
 
+# Restrict permissions at workflow level
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
+    # Pin actions to SHA for security
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b  # v4.6.0
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -36,7 +41,7 @@ jobs:
       run: ./gradlew lint
 
     - name: Upload Lint Report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
       if: always()
       with:
         name: lint-report
@@ -46,11 +51,23 @@ jobs:
     - name: Build Debug APK
       run: ./gradlew assembleDebug
 
+    # Only build signed releases for trusted contexts (not fork PRs)
+    - name: Check if secrets are available
+      id: secrets-check
+      run: |
+        if [ -n "${{ secrets.KEYSTORE_BASE64 }}" ]; then
+          echo "available=true" >> $GITHUB_OUTPUT
+        else
+          echo "available=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Decode Keystore
+      if: steps.secrets-check.outputs.available == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       run: |
         echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > ${{ github.workspace }}/release.keystore
 
     - name: Build Signed Release APK
+      if: steps.secrets-check.outputs.available == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       env:
         KEYSTORE_PATH: ${{ github.workspace }}/release.keystore
         KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -59,6 +76,7 @@ jobs:
       run: ./gradlew assembleRelease
 
     - name: Build Signed Release AAB
+      if: steps.secrets-check.outputs.available == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       env:
         KEYSTORE_PATH: ${{ github.workspace }}/release.keystore
         KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -67,25 +85,32 @@ jobs:
       run: ./gradlew bundleRelease
 
     - name: Upload Debug APK artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
       with:
         name: sappho-debug-apk
         path: app/build/outputs/apk/debug/*.apk
         retention-days: 30
 
     - name: Upload Release APK artifact
-      uses: actions/upload-artifact@v4
+      if: steps.secrets-check.outputs.available == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
       with:
         name: sappho-release-apk
         path: app/build/outputs/apk/release/*.apk
         retention-days: 30
 
     - name: Upload Release AAB artifact
-      uses: actions/upload-artifact@v4
+      if: steps.secrets-check.outputs.available == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
       with:
         name: sappho-release-aab
         path: app/build/outputs/bundle/release/*.aab
         retention-days: 30
+
+    # Clean up keystore file
+    - name: Clean up keystore
+      if: always()
+      run: rm -f ${{ github.workspace }}/release.keystore
 
   release:
     needs: build
@@ -96,19 +121,19 @@ jobs:
 
     steps:
     - name: Download Debug APK
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: sappho-debug-apk
         path: ./apk/debug
 
     - name: Download Release APK
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: sappho-release-apk
         path: ./apk/release
 
     - name: Download Release AAB
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: sappho-release-aab
         path: ./aab/release
@@ -135,7 +160,7 @@ jobs:
         mv ./aab/release/*.aab ./aab/sappho-release-${{ steps.release_name.outputs.tag }}.aab
 
     - name: Create Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda  # v2.2.1
       with:
         name: ${{ steps.release_name.outputs.name }}
         tag_name: ${{ steps.release_name.outputs.tag }}


### PR DESCRIPTION
## Summary
Security hardening for the CI workflow to protect against common attack vectors in public repositories.

## Changes

### Workflow Changes
- **SHA-pinned actions**: All GitHub Actions now use commit SHA instead of tags to prevent supply chain attacks
  - `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
  - `actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b` (v4.6.0)
  - `actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882` (v4.4.3)
  - `actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16` (v4.1.8)
  - `softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda` (v2.2.1)

- **Fork PR protection**: Signing steps are conditionally skipped for PRs from forks where secrets are not available
  - Prevents workflow failures on fork PRs
  - Protects secrets from being exposed

- **Minimal permissions**: Workflow now declares `contents: read` by default, with elevated permissions only where needed (release job)

- **Keystore cleanup**: Added step to clean up keystore file after build

### Repository Settings
- Actions restricted to GitHub-owned and verified creators only
- Added pattern allowlist for `softprops/action-gh-release`

## Security Impact
- ✅ Prevents malicious action tag mutation attacks
- ✅ Protects signing keys from fork PR attacks
- ✅ Reduces attack surface with minimal permissions
- ✅ Limits which actions can be used in workflows

## Test plan
- [ ] Verify CI passes on this PR (internal PR, should have signing)
- [ ] Verify lint, debug APK, and release artifacts are produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)