### PR TITLE
Fix playback unresponsive after service destroyed

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
@@ -891,6 +891,13 @@ class AudioPlaybackService : MediaLibraryService() {
 
     fun loadAndPlay(audiobook: Audiobook, startPosition: Int) {
         android.util.Log.d("AudioPlaybackService", "loadAndPlay called with startPosition: $startPosition seconds for book: ${audiobook.title}")
+
+        // Ensure player is initialized - reinitialize if it was released
+        if (player == null || mediaLibrarySession == null) {
+            android.util.Log.d("AudioPlaybackService", "Player or session was null, reinitializing...")
+            initializePlayer()
+        }
+
         player?.let { exoPlayer ->
             // Request audio focus before playing
             if (!requestAudioFocus()) {


### PR DESCRIPTION
## Summary
- Fixes the issue where playback would silently fail after the app had been idle for a while
- The AudioPlaybackService would be destroyed by Android to reclaim resources, and subsequent play attempts would try to use a destroyed media session

## Changes
- **PlayerViewModel**: Added retry logic (up to 2 seconds) to wait for the service to be ready instead of a fixed 500ms delay
- **AudioPlaybackService**: Added check in `loadAndPlay()` to reinitialize the player/session if they were destroyed

## Test plan
- [x] Install updated app on device that was previously in the unresponsive state
- [x] Verified playback starts successfully
- [ ] Leave app idle for extended period, then try to play again

Closes mondominator/sappho#98 (issue was filed in wrong repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)