### PR TITLE
Improve Catch Up button visibility for series books

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
@@ -195,6 +195,17 @@ interface SapphoApi {
     @DELETE("api/series/{seriesName}/recap")
     suspend fun clearSeriesRecap(@Path("seriesName", encoded = true) seriesName: String): Response<Unit>
 
+    // Audiobook Recap (Catch Up)
+    @GET("api/audiobooks/{id}/recap")
+    suspend fun getAudiobookRecap(@Path("id") audiobookId: Int): Response<AudiobookRecapResponse>
+
+    @DELETE("api/audiobooks/{id}/recap")
+    suspend fun clearAudiobookRecap(@Path("id") audiobookId: Int): Response<Unit>
+
+    // Previous Book Status (for Catch Up button visibility)
+    @GET("api/audiobooks/{id}/previous-book-status")
+    suspend fun getPreviousBookStatus(@Path("id") audiobookId: Int): Response<PreviousBookStatusResponse>
+
     // Ratings
     @GET("api/ratings/audiobook/{audiobookId}")
     suspend fun getUserRating(@Path("audiobookId") audiobookId: Int): Response<UserRating?>
@@ -458,6 +469,29 @@ data class RecapBookInfo(
     val id: Int,
     val title: String,
     val position: Float?
+)
+
+data class AudiobookRecapResponse(
+    val recap: String,
+    val cached: Boolean?,
+    @com.google.gson.annotations.SerializedName("cached_at")
+    val cachedAt: String?,
+    @com.google.gson.annotations.SerializedName("books_included")
+    val booksIncluded: List<RecapBookInfo>?
+)
+
+data class PreviousBookStatusResponse(
+    @com.google.gson.annotations.SerializedName("previousBookCompleted")
+    val previousBookCompleted: Boolean,
+    @com.google.gson.annotations.SerializedName("previousBook")
+    val previousBook: PreviousBookInfo?
+)
+
+data class PreviousBookInfo(
+    val id: Int,
+    val title: String,
+    @com.google.gson.annotations.SerializedName("series_position")
+    val seriesPosition: Float?
 )
 
 // Admin Settings Data Classes


### PR DESCRIPTION
## Summary
- Add API call to check if previous book in series is completed
- Show Catch Up button for books with no progress if the immediately previous book in the series is finished
- Prevents spoilers from allowing users to skip books in a series

## Changes
- Added `getPreviousBookStatus()` API endpoint call
- Added `PreviousBookStatusResponse` and `PreviousBookInfo` data classes
- Updated `AudiobookDetailViewModel` with `previousBookCompleted` state
- Updated button visibility logic to check previous book completion status

## Dependencies
- Requires server PR mondominator/sappho#99 (already merged)

## Test plan
- [ ] Verify Catch Up button shows for books with progress
- [ ] Verify Catch Up button shows for book 2+ when book 1 is finished
- [ ] Verify Catch Up button does NOT show for book 1 of a series
- [ ] Verify Catch Up button does NOT show for books with no progress and previous book not finished

🤖 Generated with [Claude Code](https://claude.com/claude-code)