### PR TITLE
Replace Cast button with seek buttons in mini player

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/main/MainScreen.kt
@@ -218,8 +218,7 @@ fun MainScreen(
                                 R.anim.stay
                             )
                         }
-                    },
-                    onCastClick = { showCastDialog = true }
+                    }
                 )
             }
         },


### PR DESCRIPTION
## Summary
- Replace Cast button with seek back/forward (10s) buttons in mini player
- Seek buttons now flank the play button: ⏪ ▶️ ⏩
- Fix text spacing issues from Material3 dependency update
- Cast functionality still available in full player screen

## Test plan
- [x] Verify seek back button works (skips back 10s)
- [x] Verify seek forward button works (skips forward 10s)
- [x] Verify buttons work when casting to Chromecast
- [x] Verify text spacing looks correct (title, author, time)
- [x] Verify button sizes are appropriate for touch targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)