### PR TITLE
Add Collections to navbar and sort by rating option (#63, #50)

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/data/repository/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/repository/UserPreferencesRepository.kt
@@ -16,7 +16,8 @@ enum class LibrarySortOption(val displayName: String) {
     RECENTLY_LISTENED("Recently Listened"),
     DURATION("Duration"),
     PROGRESS("Progress"),
-    SERIES_POSITION("Series Position")
+    SERIES_POSITION("Series Position"),
+    RATING("Rating")
 }
 
 enum class LibraryFilterOption(val displayName: String) {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
@@ -2866,11 +2866,13 @@ fun AllBooksView(
             }
             com.sappho.audiobooks.data.repository.LibrarySortOption.SERIES_POSITION -> compareBy<com.sappho.audiobooks.domain.model.Audiobook> { it.series ?: "\uFFFF" }
                 .thenBy { it.seriesPosition ?: 0f }
+            com.sappho.audiobooks.data.repository.LibrarySortOption.RATING -> compareByDescending { it.userRating ?: it.averageRating ?: 0f }
         }
         val sorted = filteredBooks.sortedWith(comparator)
         if (sortAscending || sortOption == com.sappho.audiobooks.data.repository.LibrarySortOption.RECENTLY_ADDED ||
             sortOption == com.sappho.audiobooks.data.repository.LibrarySortOption.RECENTLY_LISTENED ||
-            sortOption == com.sappho.audiobooks.data.repository.LibrarySortOption.PROGRESS) {
+            sortOption == com.sappho.audiobooks.data.repository.LibrarySortOption.PROGRESS ||
+            sortOption == com.sappho.audiobooks.data.repository.LibrarySortOption.RATING) {
             sorted
         } else {
             sorted.reversed()

--- a/app/src/main/java/com/sappho/audiobooks/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/main/MainScreen.kt
@@ -158,12 +158,6 @@ fun MainScreen(
                         launchSingleTop = true
                     }
                 },
-                onCollectionsClick = {
-                    showUserMenu = false
-                    navController.navigate(Screen.Collections.route) {
-                        launchSingleTop = true
-                    }
-                },
                 onSettingsClick = {
                     showUserMenu = false
                     navController.navigate(Screen.Settings.route) {
@@ -809,7 +803,6 @@ fun TopBar(
     onUserMenuToggle: () -> Unit,
     onProfileClick: () -> Unit,
     onReadingListClick: () -> Unit,
-    onCollectionsClick: () -> Unit,
     onSettingsClick: () -> Unit,
     onAdminClick: () -> Unit,
     onLogout: () -> Unit,
@@ -856,6 +849,7 @@ fun TopBar(
                 val navItems = listOf(
                     Triple(Screen.Home, Icons.Default.Home, "Home"),
                     Triple(Screen.Library, Icons.Default.MenuBook, "Library"),
+                    Triple(Screen.Collections, Icons.Default.LibraryBooks, "Collections"),
                     Triple(Screen.Search, Icons.Default.Search, "Search")
                 )
 
@@ -943,11 +937,6 @@ fun TopBar(
                         icon = Icons.Default.BookmarkAdded,
                         text = "Reading List",
                         onClick = onReadingListClick
-                    )
-                    UserMenuItem(
-                        icon = Icons.Default.LibraryBooks,
-                        text = "Collections",
-                        onClick = onCollectionsClick
                     )
                     UserMenuItem(
                         icon = Icons.Default.Download,


### PR DESCRIPTION
## Summary
- Move Collections button from user dropdown menu to the main navbar for quicker access alongside Home, Library, and Search (Fixes #63)
- Add "Rating" as a new sort option in the library view, sorting by user rating first, falling back to average rating for unrated books (Fixes #50)

## Test plan
- [ ] Verify Collections icon appears in the navbar between Library and Search
- [ ] Verify Collections is removed from the user dropdown menu
- [ ] Navigate to Library > All Books > Sort dropdown and verify "Rating" option appears
- [ ] Sort by Rating and verify books with ratings appear first, sorted highest to lowest
- [ ] Verify unrated books appear at the end of the sorted list

🤖 Generated with [Claude Code](https://claude.com/claude-code)