### PR TITLE
Reorganize navigation: Settings breakout and Library consolidation

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
@@ -136,6 +136,8 @@ enum class LibraryView {
 @Composable
 fun LibraryScreen(
     onAudiobookClick: (Int) -> Unit = {},
+    onCollectionsClick: () -> Unit = {},
+    onReadingListClick: () -> Unit = {},
     initialAuthor: String? = null,
     initialSeries: String? = null,
     viewModel: LibraryViewModel = hiltViewModel()
@@ -145,6 +147,8 @@ fun LibraryScreen(
     val authors by viewModel.authors.collectAsState()
     val genres by viewModel.genres.collectAsState()
     val allBooks by viewModel.allAudiobooks.collectAsState()
+    val collections by viewModel.collections.collectAsState()
+    val readingList by viewModel.readingList.collectAsState()
 
     // Refresh data when screen is loaded to get latest progress
     LaunchedEffect(Unit) {
@@ -192,10 +196,14 @@ fun LibraryScreen(
                     seriesCount = series.size,
                     authorsCount = authors.size,
                     genresCount = genres.size,
+                    collectionsCount = collections.size,
+                    readingListCount = readingList.size,
                     onSeriesClick = { currentViewName = LibraryView.SERIES.name },
                     onAuthorsClick = { currentViewName = LibraryView.AUTHORS.name },
                     onGenresClick = { currentViewName = LibraryView.GENRES.name },
-                    onAllBooksClick = { currentViewName = LibraryView.ALL_BOOKS.name }
+                    onAllBooksClick = { currentViewName = LibraryView.ALL_BOOKS.name },
+                    onCollectionsClick = onCollectionsClick,
+                    onReadingListClick = onReadingListClick
                 )
             }
             LibraryView.SERIES -> {
@@ -297,10 +305,14 @@ fun CategoriesView(
     seriesCount: Int,
     authorsCount: Int,
     genresCount: Int,
+    collectionsCount: Int,
+    readingListCount: Int,
     onSeriesClick: () -> Unit,
     onAuthorsClick: () -> Unit,
     onGenresClick: () -> Unit,
-    onAllBooksClick: () -> Unit
+    onAllBooksClick: () -> Unit,
+    onCollectionsClick: () -> Unit,
+    onReadingListClick: () -> Unit
 ) {
     LazyColumn(
         modifier = Modifier
@@ -340,7 +352,7 @@ fun CategoriesView(
             )
         }
 
-        // Two column cards
+        // Two column cards - Authors & Genres
         item {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -362,6 +374,33 @@ fun CategoriesView(
                     label = "genres",
                     gradientColors = listOf(Color(0xFF10b981), Color(0xFF059669)),
                     onClick = onGenresClick,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+
+        // Two column cards - Collections & Reading List
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                CategoryCardMedium(
+                    icon = Icons.Default.LibraryBooks,
+                    title = "Collections",
+                    count = collectionsCount,
+                    label = "collections",
+                    gradientColors = listOf(Color(0xFFf59e0b), Color(0xFFd97706)),
+                    onClick = onCollectionsClick,
+                    modifier = Modifier.weight(1f)
+                )
+                CategoryCardMedium(
+                    icon = Icons.Default.BookmarkAdded,
+                    title = "Reading List",
+                    count = readingListCount,
+                    label = "books",
+                    gradientColors = listOf(Color(0xFFec4899), Color(0xFFdb2777)),
+                    onClick = onReadingListClick,
                     modifier = Modifier.weight(1f)
                 )
             }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryViewModel.kt
@@ -117,6 +117,10 @@ class LibraryViewModel @Inject constructor(
     private val _collectionsForBook = MutableStateFlow<List<CollectionForBook>>(emptyList())
     val collectionsForBook: StateFlow<List<CollectionForBook>> = _collectionsForBook.asStateFlow()
 
+    // Reading list state
+    private val _readingList = MutableStateFlow<List<com.sappho.audiobooks.domain.model.Audiobook>>(emptyList())
+    val readingList: StateFlow<List<com.sappho.audiobooks.domain.model.Audiobook>> = _readingList.asStateFlow()
+
     // Batch selection state
     private val _selectedBookIds = MutableStateFlow<Set<Int>>(emptySet())
     val selectedBookIds: StateFlow<Set<Int>> = _selectedBookIds.asStateFlow()
@@ -128,6 +132,7 @@ class LibraryViewModel @Inject constructor(
         _serverUrl.value = authRepository.getServerUrlSync()
         loadCategories()
         loadCollections()
+        loadReadingList()
         checkAiStatus()
     }
 
@@ -183,6 +188,22 @@ class LibraryViewModel @Inject constructor(
     fun refresh() {
         loadCategories()
         loadCollections()
+        loadReadingList()
+    }
+
+    // Reading list methods
+    fun loadReadingList() {
+        viewModelScope.launch {
+            try {
+                val response = api.getFavorites()
+                if (response.isSuccessful) {
+                    _readingList.value = response.body() ?: emptyList()
+                    Log.d("LibraryViewModel", "Loaded ${_readingList.value.size} reading list items")
+                }
+            } catch (e: Exception) {
+                Log.e("LibraryViewModel", "Error loading reading list", e)
+            }
+        }
     }
 
     // Collection methods

--- a/app/src/main/java/com/sappho/audiobooks/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/main/MainScreen.kt
@@ -10,17 +10,17 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Book
-import androidx.compose.material.icons.filled.BookmarkAdded
 import androidx.compose.material.icons.filled.ExitToApp
 import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.LibraryBooks
 import androidx.compose.material.icons.filled.MenuBook
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Cast
+import androidx.compose.material.icons.filled.AdminPanelSettings
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.LibraryBooks
 import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material.icons.outlined.AudioFile
 import androidx.compose.material.icons.outlined.CheckCircle
@@ -152,12 +152,6 @@ fun MainScreen(
                         launchSingleTop = true
                     }
                 },
-                onReadingListClick = {
-                    showUserMenu = false
-                    navController.navigate(Screen.ReadingList.route) {
-                        launchSingleTop = true
-                    }
-                },
                 onSettingsClick = {
                     showUserMenu = false
                     navController.navigate(Screen.Settings.route) {
@@ -256,6 +250,16 @@ fun MainScreen(
                     onAudiobookClick = { audiobookId ->
                         navController.navigate(Screen.AudiobookDetail.createRoute(audiobookId))
                     },
+                    onCollectionsClick = {
+                        navController.navigate(Screen.Collections.route) {
+                            launchSingleTop = true
+                        }
+                    },
+                    onReadingListClick = {
+                        navController.navigate(Screen.ReadingList.route) {
+                            launchSingleTop = true
+                        }
+                    },
                     initialAuthor = author,
                     initialSeries = series
                 )
@@ -282,11 +286,12 @@ fun MainScreen(
                 )
             }
             composable(Screen.Profile.route) {
-                ProfileScreen(onLogout = onLogout)
+                ProfileScreen()
             }
             composable(Screen.Settings.route) {
                 com.sappho.audiobooks.presentation.settings.SettingsScreen(
-                    onBackClick = { navController.navigateUp() }
+                    onBackClick = { navController.navigateUp() },
+                    onLogout = onLogout
                 )
             }
             composable(Screen.Admin.route) {
@@ -802,7 +807,6 @@ fun TopBar(
     showUserMenu: Boolean,
     onUserMenuToggle: () -> Unit,
     onProfileClick: () -> Unit,
-    onReadingListClick: () -> Unit,
     onSettingsClick: () -> Unit,
     onAdminClick: () -> Unit,
     onLogout: () -> Unit,
@@ -934,9 +938,9 @@ fun TopBar(
                         onClick = onProfileClick
                     )
                     UserMenuItem(
-                        icon = Icons.Default.BookmarkAdded,
-                        text = "Reading List",
-                        onClick = onReadingListClick
+                        icon = Icons.Default.Settings,
+                        text = "Settings",
+                        onClick = onSettingsClick
                     )
                     UserMenuItem(
                         icon = Icons.Default.Download,
@@ -950,7 +954,7 @@ fun TopBar(
                             onClick = onUploadClick
                         )
                         UserMenuItem(
-                            icon = Icons.Default.Settings,
+                            icon = Icons.Default.AdminPanelSettings,
                             text = "Admin",
                             onClick = onAdminClick
                         )

--- a/app/src/main/java/com/sappho/audiobooks/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/profile/ProfileScreen.kt
@@ -7,8 +7,6 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -17,7 +15,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
-import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,18 +33,15 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
-import com.sappho.audiobooks.BuildConfig
-import com.sappho.audiobooks.data.repository.UserPreferencesRepository
 import kotlinx.coroutines.launch
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.*
 
-@OptIn(ExperimentalMaterial3Api::class, androidx.compose.foundation.ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProfileScreen(
-    viewModel: ProfileViewModel = hiltViewModel(),
-    onLogout: () -> Unit
+    viewModel: ProfileViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
     val user by viewModel.user.collectAsState()
@@ -57,24 +51,7 @@ fun ProfileScreen(
     val saveMessage by viewModel.saveMessage.collectAsState()
     val serverUrl by viewModel.serverUrl.collectAsState()
     val avatarUri by viewModel.avatarUri.collectAsState()
-    val serverVersion by viewModel.serverVersion.collectAsState()
-
-    // Tab state - always 2 tabs (Profile, Settings)
-    val pagerState = rememberPagerState(pageCount = { 2 })
     val coroutineScope = rememberCoroutineScope()
-
-    // Edit mode state
-    var isEditMode by remember { mutableStateOf(false) }
-    var displayName by remember(user) { mutableStateOf(user?.displayName ?: "") }
-    var email by remember(user) { mutableStateOf(user?.email ?: "") }
-
-    // Password dialog
-    var showPasswordDialog by remember { mutableStateOf(false) }
-    var currentPassword by remember { mutableStateOf("") }
-    var newPassword by remember { mutableStateOf("") }
-    var confirmPassword by remember { mutableStateOf("") }
-    var showCurrentPassword by remember { mutableStateOf(false) }
-    var showNewPassword by remember { mutableStateOf(false) }
 
     // Avatar picker
     var selectedAvatarFile by remember { mutableStateOf<File?>(null) }
@@ -293,246 +270,10 @@ fun ProfileScreen(
                     }
                 }
 
-                // Tab Row
-                TabRow(
-                    selectedTabIndex = pagerState.currentPage,
-                    containerColor = Color(0xFF0A0E1A),
-                    contentColor = Color(0xFF3b82f6),
-                    indicator = { tabPositions ->
-                        if (pagerState.currentPage < tabPositions.size) {
-                            Box(
-                                Modifier
-                                    .tabIndicatorOffset(tabPositions[pagerState.currentPage])
-                                    .height(3.dp)
-                                    .background(Color(0xFF3b82f6), RoundedCornerShape(topStart = 3.dp, topEnd = 3.dp))
-                            )
-                        }
-                    },
-                    divider = { Divider(color = Color(0xFF1e293b)) }
-                ) {
-                    Tab(
-                        selected = pagerState.currentPage == 0,
-                        onClick = { coroutineScope.launch { pagerState.animateScrollToPage(0) } },
-                        text = { Text("Profile") },
-                        icon = { Icon(Icons.Outlined.Person, contentDescription = null, modifier = Modifier.size(18.dp)) },
-                        selectedContentColor = Color(0xFF3b82f6),
-                        unselectedContentColor = Color(0xFF6b7280)
-                    )
-                    Tab(
-                        selected = pagerState.currentPage == 1,
-                        onClick = { coroutineScope.launch { pagerState.animateScrollToPage(1) } },
-                        text = { Text("Settings") },
-                        icon = { Icon(Icons.Outlined.Settings, contentDescription = null, modifier = Modifier.size(18.dp)) },
-                        selectedContentColor = Color(0xFF3b82f6),
-                        unselectedContentColor = Color(0xFF6b7280)
-                    )
-                }
-
-                // Pager content
-                HorizontalPager(
-                    state = pagerState,
-                    modifier = Modifier.fillMaxSize()
-                ) { page ->
-                    when (page) {
-                        0 -> ProfileTab(stats, serverUrl)
-                        1 -> SettingsTab(
-                            user = user,
-                            isSaving = isSaving,
-                            serverVersion = serverVersion,
-                            userPreferences = viewModel.userPreferences,
-                            onEditProfile = { isEditMode = true },
-                            onChangePassword = { showPasswordDialog = true },
-                            onLogout = onLogout
-                        )
-                    }
-                }
+                // Profile content (scrollable)
+                ProfileTab(stats, serverUrl)
             }
         }
-    }
-
-    // Edit Profile Dialog
-    if (isEditMode) {
-        AlertDialog(
-            onDismissRequest = { isEditMode = false },
-            title = { Text("Edit Profile", color = Color.White) },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                    OutlinedTextField(
-                        value = displayName,
-                        onValueChange = { displayName = it },
-                        label = { Text("Display Name") },
-                        placeholder = { Text("Your display name") },
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedTextColor = Color.White,
-                            unfocusedTextColor = Color.White,
-                            focusedBorderColor = Color(0xFF3b82f6),
-                            unfocusedBorderColor = Color(0xFF374151),
-                            focusedLabelColor = Color(0xFF3b82f6),
-                            unfocusedLabelColor = Color(0xFF9ca3af),
-                            cursorColor = Color(0xFF3b82f6)
-                        )
-                    )
-
-                    OutlinedTextField(
-                        value = email,
-                        onValueChange = { email = it },
-                        label = { Text("Email") },
-                        placeholder = { Text("your.email@example.com") },
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedTextColor = Color.White,
-                            unfocusedTextColor = Color.White,
-                            focusedBorderColor = Color(0xFF3b82f6),
-                            unfocusedBorderColor = Color(0xFF374151),
-                            focusedLabelColor = Color(0xFF3b82f6),
-                            unfocusedLabelColor = Color(0xFF9ca3af),
-                            cursorColor = Color(0xFF3b82f6)
-                        )
-                    )
-                }
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        viewModel.updateProfile(
-                            displayName.ifBlank { null },
-                            email.ifBlank { null }
-                        )
-                        isEditMode = false
-                    },
-                    enabled = !isSaving
-                ) {
-                    Text("Save", color = Color(0xFF3b82f6))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { isEditMode = false }) {
-                    Text("Cancel", color = Color(0xFF9ca3af))
-                }
-            },
-            containerColor = Color(0xFF1e293b)
-        )
-    }
-
-    // Change Password Dialog
-    if (showPasswordDialog) {
-        AlertDialog(
-            onDismissRequest = {
-                showPasswordDialog = false
-                currentPassword = ""
-                newPassword = ""
-                confirmPassword = ""
-            },
-            title = { Text("Change Password", color = Color.White) },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                    OutlinedTextField(
-                        value = currentPassword,
-                        onValueChange = { currentPassword = it },
-                        label = { Text("Current Password") },
-                        visualTransformation = if (showCurrentPassword) VisualTransformation.None else PasswordVisualTransformation(),
-                        trailingIcon = {
-                            IconButton(onClick = { showCurrentPassword = !showCurrentPassword }) {
-                                Icon(
-                                    imageVector = if (showCurrentPassword) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                                    contentDescription = "Toggle password visibility",
-                                    tint = Color(0xFF9ca3af)
-                                )
-                            }
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedTextColor = Color.White,
-                            unfocusedTextColor = Color.White,
-                            focusedBorderColor = Color(0xFF3b82f6),
-                            unfocusedBorderColor = Color(0xFF374151),
-                            focusedLabelColor = Color(0xFF3b82f6),
-                            unfocusedLabelColor = Color(0xFF9ca3af),
-                            cursorColor = Color(0xFF3b82f6)
-                        )
-                    )
-
-                    OutlinedTextField(
-                        value = newPassword,
-                        onValueChange = { newPassword = it },
-                        label = { Text("New Password") },
-                        visualTransformation = if (showNewPassword) VisualTransformation.None else PasswordVisualTransformation(),
-                        trailingIcon = {
-                            IconButton(onClick = { showNewPassword = !showNewPassword }) {
-                                Icon(
-                                    imageVector = if (showNewPassword) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                                    contentDescription = "Toggle password visibility",
-                                    tint = Color(0xFF9ca3af)
-                                )
-                            }
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedTextColor = Color.White,
-                            unfocusedTextColor = Color.White,
-                            focusedBorderColor = Color(0xFF3b82f6),
-                            unfocusedBorderColor = Color(0xFF374151),
-                            focusedLabelColor = Color(0xFF3b82f6),
-                            unfocusedLabelColor = Color(0xFF9ca3af),
-                            cursorColor = Color(0xFF3b82f6)
-                        )
-                    )
-
-                    OutlinedTextField(
-                        value = confirmPassword,
-                        onValueChange = { confirmPassword = it },
-                        label = { Text("Confirm New Password") },
-                        visualTransformation = PasswordVisualTransformation(),
-                        isError = confirmPassword.isNotEmpty() && confirmPassword != newPassword,
-                        supportingText = if (confirmPassword.isNotEmpty() && confirmPassword != newPassword) {
-                            { Text("Passwords do not match", color = Color(0xFFef4444)) }
-                        } else null,
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedTextColor = Color.White,
-                            unfocusedTextColor = Color.White,
-                            focusedBorderColor = Color(0xFF3b82f6),
-                            unfocusedBorderColor = Color(0xFF374151),
-                            focusedLabelColor = Color(0xFF3b82f6),
-                            unfocusedLabelColor = Color(0xFF9ca3af),
-                            cursorColor = Color(0xFF3b82f6),
-                            errorBorderColor = Color(0xFFef4444),
-                            errorLabelColor = Color(0xFFef4444)
-                        )
-                    )
-                }
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        if (newPassword == confirmPassword && currentPassword.isNotBlank() && newPassword.isNotBlank()) {
-                            viewModel.updatePassword(currentPassword, newPassword)
-                            showPasswordDialog = false
-                            currentPassword = ""
-                            newPassword = ""
-                            confirmPassword = ""
-                        }
-                    },
-                    enabled = currentPassword.isNotBlank() && newPassword.isNotBlank() && newPassword == confirmPassword && !isSaving
-                ) {
-                    Text("Update Password", color = Color(0xFF3b82f6))
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = {
-                        showPasswordDialog = false
-                        currentPassword = ""
-                        newPassword = ""
-                        confirmPassword = ""
-                    }
-                ) {
-                    Text("Cancel", color = Color(0xFF9ca3af))
-                }
-            },
-            containerColor = Color(0xFF1e293b)
-        )
     }
 }
 
@@ -758,160 +499,6 @@ private fun ProfileTab(
 }
 
 @Composable
-private fun SettingsTab(
-    user: com.sappho.audiobooks.domain.model.User?,
-    isSaving: Boolean,
-    serverVersion: String?,
-    userPreferences: UserPreferencesRepository,
-    onEditProfile: () -> Unit,
-    onChangePassword: () -> Unit,
-    onLogout: () -> Unit
-) {
-    val skipForward by userPreferences.skipForwardSeconds.collectAsState()
-    val skipBackward by userPreferences.skipBackwardSeconds.collectAsState()
-
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp)
-    ) {
-        // Playback Section
-        SectionCard(
-            title = "Playback",
-            icon = Icons.Outlined.PlayCircle
-        ) {
-            // Skip Forward Setting
-            SkipIntervalSelector(
-                label = "Skip Forward",
-                currentValue = skipForward,
-                options = UserPreferencesRepository.SKIP_FORWARD_OPTIONS,
-                onValueChange = { userPreferences.setSkipForwardSeconds(it) }
-            )
-
-            Divider(color = Color(0xFF374151), modifier = Modifier.padding(vertical = 8.dp))
-
-            // Skip Backward Setting
-            SkipIntervalSelector(
-                label = "Skip Back",
-                currentValue = skipBackward,
-                options = UserPreferencesRepository.SKIP_BACKWARD_OPTIONS,
-                onValueChange = { userPreferences.setSkipBackwardSeconds(it) }
-            )
-
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = "Changes take effect on next playback start",
-                color = Color(0xFF6b7280),
-                fontSize = 12.sp,
-                modifier = Modifier.padding(top = 4.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Account Section
-        SectionCard(
-            title = "Account",
-            icon = Icons.Outlined.Person
-        ) {
-            SettingsRow(
-                icon = Icons.Outlined.Edit,
-                title = "Edit Profile",
-                subtitle = "Update your display name and email",
-                onClick = onEditProfile
-            )
-
-            Divider(color = Color(0xFF374151), modifier = Modifier.padding(vertical = 8.dp))
-
-            SettingsRow(
-                icon = Icons.Outlined.Lock,
-                title = "Change Password",
-                subtitle = "Update your account password",
-                onClick = onChangePassword
-            )
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // About Section
-        SectionCard(
-            title = "About",
-            icon = Icons.Outlined.Info
-        ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 12.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = "App Version",
-                    color = Color.White,
-                    fontSize = 15.sp
-                )
-                Text(
-                    text = BuildConfig.VERSION_NAME,
-                    color = Color(0xFF9ca3af),
-                    fontSize = 14.sp
-                )
-            }
-
-            Divider(color = Color(0xFF374151), modifier = Modifier.padding(vertical = 4.dp))
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 12.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = "Server Version",
-                    color = Color.White,
-                    fontSize = 15.sp
-                )
-                Text(
-                    text = serverVersion ?: "Unknown",
-                    color = Color(0xFF9ca3af),
-                    fontSize = 14.sp
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        // Logout Button
-        Button(
-            onClick = onLogout,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(52.dp),
-            shape = RoundedCornerShape(12.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color(0xFF374151),
-                contentColor = Color.White
-            )
-        ) {
-            Icon(
-                imageVector = Icons.Default.ExitToApp,
-                contentDescription = "Logout",
-                modifier = Modifier.size(20.dp)
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = "Logout",
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Medium
-            )
-        }
-
-        Spacer(modifier = Modifier.height(32.dp))
-    }
-}
-
-@Composable
 private fun StatCard(
     modifier: Modifier = Modifier,
     value: String,
@@ -995,50 +582,6 @@ private fun SectionCard(
     }
 }
 
-@Composable
-private fun SettingsRow(
-    icon: ImageVector,
-    title: String,
-    subtitle: String,
-    iconTint: Color = Color(0xFF9ca3af),
-    onClick: () -> Unit
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = iconTint,
-            modifier = Modifier.size(22.dp)
-        )
-        Spacer(modifier = Modifier.width(16.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = title,
-                color = Color.White,
-                fontSize = 15.sp,
-                fontWeight = FontWeight.Medium
-            )
-            Text(
-                text = subtitle,
-                color = Color(0xFF6b7280),
-                fontSize = 13.sp
-            )
-        }
-        Icon(
-            imageVector = Icons.Default.ChevronRight,
-            contentDescription = null,
-            tint = Color(0xFF6b7280),
-            modifier = Modifier.size(20.dp)
-        )
-    }
-}
-
 private fun formatListenTime(seconds: Long): String {
     val hours = seconds / 3600
     val minutes = (seconds % 3600) / 60
@@ -1052,63 +595,5 @@ private fun formatListenTime(seconds: Long): String {
         hours > 0 -> "${hours}h ${minutes}m"
         minutes > 0 -> "${minutes}m"
         else -> "${seconds}s"
-    }
-}
-
-@Composable
-private fun SkipIntervalSelector(
-    label: String,
-    currentValue: Int,
-    options: List<Int>,
-    onValueChange: (Int) -> Unit
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp)
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = label,
-                color = Color.White,
-                fontSize = 15.sp,
-                fontWeight = FontWeight.Medium
-            )
-            Text(
-                text = "${currentValue}s",
-                color = Color(0xFF3b82f6),
-                fontSize = 14.sp,
-                fontWeight = FontWeight.Medium
-            )
-        }
-        Spacer(modifier = Modifier.height(10.dp))
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            options.forEach { seconds ->
-                val isSelected = seconds == currentValue
-                Surface(
-                    modifier = Modifier
-                        .weight(1f)
-                        .clickable { onValueChange(seconds) },
-                    shape = RoundedCornerShape(8.dp),
-                    color = if (isSelected) Color(0xFF3b82f6) else Color(0xFF374151)
-                ) {
-                    Text(
-                        text = "${seconds}s",
-                        color = if (isSelected) Color.White else Color(0xFF9ca3af),
-                        fontSize = 13.sp,
-                        fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(vertical = 10.dp, horizontal = 4.dp)
-                    )
-                }
-            }
-        }
     }
 }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/settings/UserSettingsViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/settings/UserSettingsViewModel.kt
@@ -1,0 +1,115 @@
+package com.sappho.audiobooks.presentation.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sappho.audiobooks.data.remote.SapphoApi
+import com.sappho.audiobooks.data.remote.PasswordUpdateRequest
+import com.sappho.audiobooks.data.remote.ProfileUpdateRequest
+import com.sappho.audiobooks.data.repository.AuthRepository
+import com.sappho.audiobooks.data.repository.UserPreferencesRepository
+import com.sappho.audiobooks.domain.model.User
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class UserSettingsViewModel @Inject constructor(
+    private val api: SapphoApi,
+    private val authRepository: AuthRepository,
+    val userPreferences: UserPreferencesRepository
+) : ViewModel() {
+
+    private val _user = MutableStateFlow<User?>(null)
+    val user: StateFlow<User?> = _user
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _isSaving = MutableStateFlow(false)
+    val isSaving: StateFlow<Boolean> = _isSaving
+
+    private val _message = MutableStateFlow<String?>(null)
+    val message: StateFlow<String?> = _message
+
+    private val _serverVersion = MutableStateFlow<String?>(null)
+    val serverVersion: StateFlow<String?> = _serverVersion
+
+    init {
+        loadProfile()
+        loadServerVersion()
+    }
+
+    private fun loadProfile() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            try {
+                val response = api.getProfile()
+                if (response.isSuccessful) {
+                    _user.value = response.body()
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    private fun loadServerVersion() {
+        viewModelScope.launch {
+            try {
+                val response = api.getHealth()
+                if (response.isSuccessful) {
+                    _serverVersion.value = response.body()?.version
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    fun updateProfile(displayName: String?, email: String?) {
+        viewModelScope.launch {
+            _isSaving.value = true
+            try {
+                val response = api.updateProfile(ProfileUpdateRequest(displayName, email))
+                if (response.isSuccessful) {
+                    _user.value = response.body()
+                    _message.value = "Profile updated"
+                } else {
+                    _message.value = "Failed to update profile"
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                _message.value = "Error: ${e.message}"
+            } finally {
+                _isSaving.value = false
+            }
+        }
+    }
+
+    fun updatePassword(currentPassword: String, newPassword: String) {
+        viewModelScope.launch {
+            _isSaving.value = true
+            try {
+                val response = api.updatePassword(PasswordUpdateRequest(currentPassword, newPassword))
+                if (response.isSuccessful) {
+                    _message.value = "Password updated"
+                } else {
+                    _message.value = response.errorBody()?.string() ?: "Failed to update password"
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                _message.value = "Error: ${e.message}"
+            } finally {
+                _isSaving.value = false
+            }
+        }
+    }
+
+    fun clearMessage() {
+        _message.value = null
+    }
+}


### PR DESCRIPTION
## Summary
- Break out Settings tab from ProfileScreen into standalone SettingsScreen accessible via user dropdown
- Add UserSettingsViewModel for settings functionality (profile, password updates)
- Move Collections and Reading List access into Library categories instead of navbar/dropdown
- ProfileScreen simplified to show only profile stats (listening time, top authors, genres)

## Test plan
- [ ] Verify Settings screen opens from user dropdown → Settings
- [ ] Test skip interval settings work correctly
- [ ] Test Edit Profile dialog saves changes
- [ ] Test Change Password dialog
- [ ] Verify logout button works from Settings
- [ ] Check Collections accessible from Library categories
- [ ] Check Reading List accessible from Library categories
- [ ] Verify Profile screen shows stats without tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)