### PR TITLE
Fix cover image not refreshing after metadata update

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
@@ -77,6 +77,7 @@ fun AudiobookDetailScreen(
     val chapters by viewModel.chapters.collectAsState()
     val files by viewModel.files.collectAsState()
     val serverUrl by viewModel.serverUrl.collectAsState()
+    val coverVersion by viewModel.coverVersion.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     val isOffline by viewModel.isOffline.collectAsState()
     val isFavorite by viewModel.isFavorite.collectAsState()
@@ -256,9 +257,14 @@ fun AudiobookDetailScreen(
                                     .background(SapphoProgressTrack)
                             ) {
                                 if (book.coverImage != null && serverUrl != null) {
-                                    // Let Coil try to load - it may have the image cached
+                                    // Let Coil try to load - use coverVersion for cache busting after metadata updates
+                                    val coverUrl = if (coverVersion > 0) {
+                                        "$serverUrl/api/audiobooks/${book.id}/cover?v=$coverVersion"
+                                    } else {
+                                        "$serverUrl/api/audiobooks/${book.id}/cover"
+                                    }
                                     AsyncImage(
-                                        model = "$serverUrl/api/audiobooks/${book.id}/cover",
+                                        model = coverUrl,
                                         contentDescription = book.title,
                                         modifier = Modifier.fillMaxSize(),
                                         contentScale = ContentScale.Crop

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModel.kt
@@ -59,6 +59,10 @@ class AudiobookDetailViewModel @Inject constructor(
     private val _serverUrl = MutableStateFlow<String?>(null)
     val serverUrl: StateFlow<String?> = _serverUrl
 
+    // Cover version for cache busting - increment after metadata updates
+    private val _coverVersion = MutableStateFlow(0L)
+    val coverVersion: StateFlow<Long> = _coverVersion
+
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading
 
@@ -417,6 +421,8 @@ class AudiobookDetailViewModel @Inject constructor(
                     val response = api.updateAudiobook(book.id, request)
                     if (response.isSuccessful) {
                         _metadataSaveResult.value = "Metadata saved successfully"
+                        // Increment cover version to bust image cache
+                        _coverVersion.value = System.currentTimeMillis()
                         // Reload audiobook to get updated data
                         loadAudiobook(book.id)
                         onSuccess()
@@ -484,6 +490,10 @@ class AudiobookDetailViewModel @Inject constructor(
                     val response = api.embedMetadata(book.id)
                     if (response.isSuccessful) {
                         _embedMetadataResult.value = response.body()?.message ?: "Metadata embedded successfully"
+                        // Increment cover version to bust image cache
+                        _coverVersion.value = System.currentTimeMillis()
+                        // Reload audiobook to refresh any updated data
+                        loadAudiobook(book.id)
                     } else {
                         // Try to parse error message from server response
                         val errorBody = response.errorBody()?.string()


### PR DESCRIPTION
## Summary
- Fix cover image not refreshing after metadata update/embed operations

## Changes
- Add `coverVersion` state to ViewModel for cache busting
- Increment `coverVersion` after successful `updateMetadata` and `embedMetadata`
- Add `coverVersion` as query parameter to cover image URL
- Also reload audiobook data after `embedMetadata` succeeds

This ensures Coil fetches a fresh cover image after metadata operations instead of serving a cached version.

## Test plan
- [x] Update metadata with new cover - cover refreshes immediately
- [x] Embed metadata - cover refreshes without app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)