### PR TITLE
Typography migration: major elements in Library, Detail, Admin screens

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/presentation/admin/AdminScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/admin/AdminScreen.kt
@@ -1130,8 +1130,7 @@ private fun UsersTab(viewModel: AdminViewModel) {
                     Text(
                         "User Management",
                         color = Color.White,
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.Bold
+                        style = MaterialTheme.typography.titleLarge
                     )
                     Button(
                         onClick = { showCreateDialog = true },
@@ -1487,8 +1486,7 @@ private fun ApiKeysTab(viewModel: AdminViewModel) {
                     Text(
                         "API Key Management",
                         color = Color.White,
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.Bold
+                        style = MaterialTheme.typography.titleLarge
                     )
                     Button(
                         onClick = { showCreateDialog = true },
@@ -1961,8 +1959,7 @@ private fun BackupTab(viewModel: AdminViewModel) {
                     Text(
                         "Backups",
                         color = Color.White,
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.Bold
+                        style = MaterialTheme.typography.titleLarge
                     )
                     Button(
                         onClick = { viewModel.createBackup() },
@@ -2397,8 +2394,7 @@ private fun LogsTab(viewModel: AdminViewModel) {
             Text(
                 "Server Logs",
                 color = Color.White,
-                fontSize = 18.sp,
-                fontWeight = FontWeight.Bold
+                style = MaterialTheme.typography.titleLarge
             )
             Row(
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -2957,8 +2953,7 @@ private fun StatCard(
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = value,
-                fontSize = 20.sp,
-                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.headlineSmall,
                 color = Color.White
             )
             Spacer(modifier = Modifier.height(2.dp))

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
@@ -733,8 +733,7 @@ fun AudiobookDetailScreen(
                             ) {
                                 Text(
                                     text = "Progress",
-                                    fontSize = 20.sp,
-                                    fontWeight = FontWeight.Bold,
+                                    style = MaterialTheme.typography.headlineSmall,
                                     color = Color.White,
                                     modifier = Modifier.padding(bottom = 12.dp)
                                 )
@@ -783,8 +782,7 @@ fun AudiobookDetailScreen(
                                             if (prog.completed != 1) {
                                                 Text(
                                                     text = "$percentage%",
-                                                    fontSize = 20.sp,
-                                                    fontWeight = FontWeight.Bold,
+                                                    style = MaterialTheme.typography.headlineSmall,
                                                     color = SapphoInfo
                                                 )
                                             }
@@ -879,8 +877,7 @@ fun AudiobookDetailScreen(
                             ) {
                                 Text(
                                     text = "About",
-                                    fontSize = 20.sp,
-                                    fontWeight = FontWeight.Bold,
+                                    style = MaterialTheme.typography.headlineSmall,
                                     color = Color.White
                                 )
 
@@ -1174,8 +1171,7 @@ fun AudiobookDetailScreen(
                                 Spacer(modifier = Modifier.width(12.dp))
                                 Text(
                                     text = "Catch Up",
-                                    fontSize = 20.sp,
-                                    fontWeight = FontWeight.Bold,
+                                    style = MaterialTheme.typography.headlineSmall,
                                     color = Color.White
                                 )
                             }
@@ -3356,8 +3352,7 @@ private fun AddToCollectionDialog(
                 ) {
                     Text(
                         text = "Add to Collection",
-                        fontSize = 20.sp,
-                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.headlineSmall,
                         color = Color.White
                     )
                     IconButton(

--- a/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
@@ -447,16 +447,14 @@ fun CategoryCardLarge(
             Column {
                 Text(
                     text = title,
-                    fontSize = 24.sp,
-                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.headlineLarge,
                     color = Color.White
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Row(verticalAlignment = Alignment.Bottom) {
                     Text(
                         text = "$count",
-                        fontSize = 40.sp,
-                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.displayMedium,
                         color = Color.White
                     )
                     Spacer(modifier = Modifier.width(8.dp))
@@ -579,8 +577,7 @@ fun CategoryCardWide(
                 Column {
                     Text(
                         text = title,
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.SemiBold,
+                        style = MaterialTheme.typography.titleLarge,
                         color = Color.White
                     )
                     Text(
@@ -630,8 +627,7 @@ fun SeriesListView(
             Column {
                 Text(
                     text = "Series",
-                    fontSize = 24.sp,
-                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.headlineLarge,
                     color = Color.White
                 )
                 Text(
@@ -835,8 +831,7 @@ fun AuthorsListView(
             Column {
                 Text(
                     text = "Authors",
-                    fontSize = 24.sp,
-                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.headlineLarge,
                     color = Color.White
                 )
                 Text(
@@ -1072,8 +1067,7 @@ fun GenresListView(
             Column {
                 Text(
                     text = "Genres",
-                    fontSize = 24.sp,
-                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.headlineLarge,
                     color = Color.White
                 )
                 Text(
@@ -1166,8 +1160,7 @@ fun GenreListCard(
             ) {
                 Text(
                     text = genreName,
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.titleLarge,
                     color = Color.White,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
@@ -1372,8 +1365,7 @@ fun SeriesBooksView(
             ) {
                 Text(
                     text = seriesName,
-                    fontSize = 24.sp,
-                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.headlineLarge,
                     color = Color.White,
                     textAlign = TextAlign.Center
                 )
@@ -1718,8 +1710,7 @@ fun SeriesBooksView(
             ) {
                 Text(
                     text = "Books in Series",
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.SemiBold,
+                    style = MaterialTheme.typography.titleLarge,
                     color = Color.White
                 )
             }
@@ -1761,8 +1752,7 @@ fun StatCard(
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text = value,
-            fontSize = 18.sp,
-            fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.titleLarge,
             color = Color.White
         )
         Text(
@@ -2207,8 +2197,7 @@ fun AuthorBookCard(
                 ) {
                     Text(
                         text = book.title.take(2).uppercase(),
-                        fontSize = 24.sp,
-                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.headlineLarge,
                         color = Color.White
                     )
                 }
@@ -2545,8 +2534,7 @@ fun GenreStatCard(
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text = value,
-            fontSize = 18.sp,
-            fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.titleLarge,
             color = Color.White
         )
         Text(
@@ -2704,8 +2692,7 @@ fun BookGridItem(
             ) {
                 Text(
                     text = book.title.take(2).uppercase(),
-                    fontSize = 24.sp,
-                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.headlineLarge,
                     color = Color.White
                 )
             }
@@ -3166,8 +3153,7 @@ fun SelectableBookGridItem(
             ) {
                 Text(
                     text = book.title.take(2).uppercase(),
-                    fontSize = 24.sp,
-                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.headlineLarge,
                     color = Color.White
                 )
             }


### PR DESCRIPTION
## Summary
- Migrates major typography elements from inline fontSize/fontWeight to MaterialTheme.typography styles
- LibraryScreen: 8 changes (24sp → headlineLarge, 40sp → displayMedium, 18sp → titleLarge)
- AudiobookDetailScreen: 5 changes (20sp → headlineSmall)
- AdminScreen: 5 changes (18sp → titleLarge, 20sp → headlineSmall)

## Issues
Closes #80 (LibraryScreen typography)
Closes #81 (AudiobookDetailScreen typography)
Closes #82 (AdminScreen typography)

## Test plan
- [ ] Verify LibraryScreen headers and section titles display correctly
- [ ] Verify AudiobookDetailScreen headings display correctly
- [ ] Verify AdminScreen section headers display correctly
- [ ] Confirm no visual regressions in text sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)