### PR TITLE
Fix auth redirect: handle 403 responses for expired tokens

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
+++ b/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
@@ -112,11 +112,12 @@ object NetworkModule {
                     chain.proceed(request)
                 }
             }
-            // Interceptor to detect 401 Unauthorized responses
+            // Interceptor to detect auth errors (401 Unauthorized or 403 Forbidden with token error)
             .addInterceptor { chain ->
                 val response = chain.proceed(chain.request())
-                if (response.code == 401) {
+                if (response.code == 401 || response.code == 403) {
                     // Token expired or invalid - trigger auth error
+                    android.util.Log.d("NetworkModule", "Auth error detected: ${response.code}")
                     authRepository.triggerAuthError()
                 }
                 response

--- a/app/src/main/java/com/sappho/audiobooks/presentation/SapphoApp.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/SapphoApp.kt
@@ -39,6 +39,19 @@ fun SapphoApp(
         }
     }
 
+    // Redirect to login if auth state becomes invalid while on main screen
+    LaunchedEffect(isAuthenticated) {
+        if (!isAuthenticated) {
+            val currentRoute = navController.currentDestination?.route
+            if (currentRoute == "main") {
+                android.util.Log.d("SapphoApp", "Auth state invalid on main screen - redirecting to login")
+                navController.navigate("login") {
+                    popUpTo(0) { inclusive = true }
+                }
+            }
+        }
+    }
+
     NavHost(
         navController = navController,
         startDestination = startDestination


### PR DESCRIPTION
## Summary
- Server returns 403 Forbidden (not 401) for invalid/expired tokens
- Added 403 to auth error detection in NetworkModule interceptor
- Added LaunchedEffect to watch `isAuthenticated` state changes
- Redirects to login when auth becomes invalid while on main screen

## Root Cause
The app was stuck in a "zombie state" where the token existed locally but was invalid on the server. API calls returned 403 with `{"error":"Invalid or expired token"}` but the interceptor only checked for 401.

## Test plan
- [ ] With an expired/invalid token, app should redirect to login screen
- [ ] Normal login flow still works
- [ ] Logout button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)