### PR TITLE
Android: hardcode 10s seek and add library management features

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
@@ -324,6 +324,20 @@ interface SapphoApi {
     @POST("api/maintenance/jobs/{jobId}/trigger")
     suspend fun triggerJob(@Path("jobId") jobId: String): Response<TriggerJobResponse>
 
+    // Orphan Directories
+    @GET("api/maintenance/orphan-directories")
+    suspend fun getOrphanDirectories(): Response<OrphanDirectoriesResponse>
+
+    @HTTP(method = "DELETE", path = "api/maintenance/orphan-directories", hasBody = true)
+    suspend fun deleteOrphanDirectories(@Body request: DeleteOrphansRequest): Response<DeleteOrphansResult>
+
+    // Library Organization
+    @GET("api/maintenance/organize/preview")
+    suspend fun getOrganizePreview(): Response<OrganizePreviewResponse>
+
+    @POST("api/maintenance/organize")
+    suspend fun organizeLibrary(): Response<OrganizeResult>
+
     // Collections Endpoints
     @GET("api/collections")
     suspend fun getCollections(): Response<List<Collection>>
@@ -802,6 +816,60 @@ data class JobInfo(
 data class TriggerJobResponse(
     val success: Boolean,
     val message: String?
+)
+
+// Orphan Directories Data Classes
+data class OrphanDirectoriesResponse(
+    val orphanDirectories: List<OrphanDirectory>?,
+    val totalCount: Int?,
+    val totalSize: Long?
+)
+
+data class OrphanDirectory(
+    val path: String,
+    val relativePath: String?,
+    val totalSize: Long,
+    val audioFiles: List<String>?,
+    val otherFiles: List<String>?,
+    val audioFileCount: Int?,
+    val otherFileCount: Int?,
+    val orphanType: String?
+)
+
+data class DeleteOrphansRequest(
+    val paths: List<String>
+)
+
+data class DeleteOrphansResult(
+    val success: Boolean,
+    val deleted: Int?,
+    val failed: Int?,
+    val errors: List<String>?
+)
+
+// Library Organization Data Classes
+data class OrganizePreviewResponse(
+    val books: List<OrganizePreviewBook>?
+)
+
+data class OrganizePreviewBook(
+    val id: Int,
+    val title: String,
+    val author: String?,
+    val currentPath: String?,
+    val targetPath: String?
+)
+
+data class OrganizeResult(
+    val success: Boolean,
+    val message: String?,
+    val stats: OrganizeStats?
+)
+
+data class OrganizeStats(
+    val moved: Int?,
+    val skipped: Int?,
+    val errors: Int?
 )
 
 // Collections Data Classes

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
@@ -465,7 +465,7 @@ fun PlayerScreen(
                             )
                         }
 
-                        // Skip Backward 15s
+                        // Skip Backward 10s
                         val skipBackSource = remember { MutableInteractionSource() }
                         val isSkipBackPressed by skipBackSource.collectIsPressedAsState()
                         val skipBackScale by animateFloatAsState(
@@ -481,7 +481,7 @@ fun PlayerScreen(
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Replay10,
-                                contentDescription = "Skip backward 15s",
+                                contentDescription = "Skip backward 10s",
                                 tint = Color.White,
                                 modifier = Modifier
                                     .size(36.dp)
@@ -549,7 +549,7 @@ fun PlayerScreen(
                             }
                         }
 
-                        // Skip Forward 15s
+                        // Skip Forward 10s
                         val skipForwardSource = remember { MutableInteractionSource() }
                         val isSkipForwardPressed by skipForwardSource.collectIsPressedAsState()
                         val skipForwardScale by animateFloatAsState(
@@ -565,7 +565,7 @@ fun PlayerScreen(
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Forward10,
-                                contentDescription = "Skip forward 15s",
+                                contentDescription = "Skip forward 10s",
                                 tint = Color.White,
                                 modifier = Modifier
                                     .size(36.dp)

--- a/app/src/main/java/com/sappho/audiobooks/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/settings/SettingsScreen.kt
@@ -20,12 +20,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.sappho.audiobooks.BuildConfig
-import com.sappho.audiobooks.data.repository.UserPreferencesRepository
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -39,8 +36,6 @@ fun SettingsScreen(
     val isSaving by viewModel.isSaving.collectAsState()
     val message by viewModel.message.collectAsState()
     val serverVersion by viewModel.serverVersion.collectAsState()
-    val skipForward by viewModel.userPreferences.skipForwardSeconds.collectAsState()
-    val skipBackward by viewModel.userPreferences.skipBackwardSeconds.collectAsState()
 
     // Edit mode state
     var isEditMode by remember { mutableStateOf(false) }
@@ -112,40 +107,6 @@ fun SettingsScreen(
                     .verticalScroll(rememberScrollState())
                     .padding(16.dp)
             ) {
-                // Playback Section
-                SectionCard(
-                    title = "Playback",
-                    icon = Icons.Outlined.PlayCircle
-                ) {
-                    // Skip Forward Setting
-                    SkipIntervalSelector(
-                        label = "Skip Forward",
-                        currentValue = skipForward,
-                        options = UserPreferencesRepository.SKIP_FORWARD_OPTIONS,
-                        onValueChange = { viewModel.userPreferences.setSkipForwardSeconds(it) }
-                    )
-
-                    HorizontalDivider(color = SapphoProgressTrack, modifier = Modifier.padding(vertical = 8.dp))
-
-                    // Skip Backward Setting
-                    SkipIntervalSelector(
-                        label = "Skip Back",
-                        currentValue = skipBackward,
-                        options = UserPreferencesRepository.SKIP_BACKWARD_OPTIONS,
-                        onValueChange = { viewModel.userPreferences.setSkipBackwardSeconds(it) }
-                    )
-
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        text = "Changes take effect on next playback start",
-                        color = SapphoTextMuted,
-                        style = MaterialTheme.typography.labelMedium,
-                        modifier = Modifier.padding(top = 4.dp)
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
                 // Account Section
                 SectionCard(
                     title = "Account",
@@ -512,60 +473,5 @@ private fun SettingsRow(
             tint = SapphoTextMuted,
             modifier = Modifier.size(20.dp)
         )
-    }
-}
-
-@Composable
-private fun SkipIntervalSelector(
-    label: String,
-    currentValue: Int,
-    options: List<Int>,
-    onValueChange: (Int) -> Unit
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp)
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = label,
-                color = Color.White,
-                style = MaterialTheme.typography.titleSmall
-            )
-            Text(
-                text = "${currentValue}s",
-                color = SapphoInfo,
-                style = MaterialTheme.typography.labelLarge
-            )
-        }
-        Spacer(modifier = Modifier.height(10.dp))
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            options.forEach { seconds ->
-                val isSelected = seconds == currentValue
-                Surface(
-                    modifier = Modifier
-                        .weight(1f)
-                        .clickable { onValueChange(seconds) },
-                    shape = RoundedCornerShape(8.dp),
-                    color = if (isSelected) SapphoInfo else SapphoProgressTrack
-                ) {
-                    Text(
-                        text = "${seconds}s",
-                        color = if (isSelected) Color.White else SapphoIconDefault,
-                        style = MaterialTheme.typography.bodySmall,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(vertical = 10.dp, horizontal = 4.dp)
-                    )
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Remove skip interval settings from SettingsScreen - hardcode seek to 10 seconds everywhere
- Add Reorganize Library button with preview dialog showing before/after paths
- Add Orphan Directories section with multi-select and delete functionality
- Show Duplicates and Orphans sections even when empty (like web client)

## Changes
- **SettingsScreen.kt**: Removed Playback section with skip settings
- **AudioPlaybackService.kt**: Hardcoded `SKIP_SECONDS = 10L`, removed UserPreferencesRepository
- **MinimizedPlayerBar.kt**: Updated Cast seek to use 10 seconds
- **PlayerActivity.kt**: Updated labels to 10s
- **SapphoApi.kt**: Added orphan and organize endpoints with data classes
- **AdminViewModel.kt**: Added orphan/organize state and functions
- **AdminScreen.kt**: Added OrphanDirectoryCard, OrganizePreviewDialog, always-show sections

## Test plan
- [ ] Verify seek buttons skip 10 seconds in mini player and full player
- [ ] Verify Settings no longer shows skip interval options
- [ ] Go to Admin > Library tab and verify Duplicates and Orphans sections appear
- [ ] Test Reorganize Library button shows preview dialog
- [ ] Test orphan directory selection and delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)