### PR TITLE
Update CLAUDE.md: emphasize never pushing directly to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,10 +256,13 @@ Text(color = SapphoTextSecondary)
 
 ## PR Workflow
 
+**CRITICAL: Never push directly to main. Always create a branch and PR.**
+
+- When asked to "ship it", "commit", or similar - create a feature branch first, then open a PR
 - Always work on a new branch and merge back in via PR
 - Don't use automerge - wait for pipelines to give results before moving on or declaring success
 - Wait for user testing before shipping/merging
-- Never bypass merge rules
+- Never bypass merge rules or force push to main
 
 ## Remote Server Access (Unraid)
 


### PR DESCRIPTION
## Summary
- Added critical warning to never push directly to main
- Clarified that "ship it" means create a branch and PR, not push to main
- Added explicit note about never force pushing to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)