### PR TITLE
fix: set audio attributes on ExoPlayer for Bluetooth routing

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
@@ -16,6 +16,7 @@ import androidx.core.app.NotificationCompat
 import android.net.Uri
 import android.os.Bundle
 import androidx.core.content.ContextCompat
+import androidx.media3.common.AudioAttributes as Media3AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.MediaItem
@@ -349,6 +350,15 @@ class AudioPlaybackService : MediaLibraryService() {
                 }
             })
         }
+
+        // Set audio attributes on ExoPlayer for proper Bluetooth/audio routing
+        // This tells the system what type of audio we're playing (speech media)
+        val media3AudioAttributes = Media3AudioAttributes.Builder()
+            .setUsage(C.USAGE_MEDIA)
+            .setContentType(C.AUDIO_CONTENT_TYPE_SPEECH)
+            .build()
+        // handleAudioFocus=false because we manage audio focus manually via requestAudioFocus()
+        player?.setAudioAttributes(media3AudioAttributes, false)
 
         // Create command buttons for notification using standard player commands
         // This helps the notification provider recognize them as seek buttons


### PR DESCRIPTION
## Summary
- Fixed Bluetooth audio not playing on first press after connecting
- Added Media3 AudioAttributes to ExoPlayer with `USAGE_MEDIA` and `AUDIO_CONTENT_TYPE_SPEECH`
- Audio attributes were previously only set on `AudioFocusRequest`, not on ExoPlayer itself

## Root Cause
ExoPlayer didn't know it was playing speech/media content, so Bluetooth routing failed until something forced a refresh (like switching books).

## Test plan
- [ ] Connect to Bluetooth device
- [ ] Open audiobook and press play
- [ ] Verify audio plays immediately without needing to switch books

🤖 Generated with [Claude Code](https://claude.com/claude-code)