### PR TITLE
fix: persist playback speed setting across sessions

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/repository/AuthRepository.kt
@@ -121,6 +121,15 @@ class AuthRepository @Inject constructor(
         clearCachedAvatarImage()
     }
 
+    // Playback speed preference (global setting)
+    fun savePlaybackSpeed(speed: Float) {
+        securePrefs.edit().putFloat(KEY_PLAYBACK_SPEED, speed).apply()
+    }
+
+    fun getPlaybackSpeed(): Float {
+        return securePrefs.getFloat(KEY_PLAYBACK_SPEED, 1.0f)
+    }
+
     private fun createEncryptedPrefs(): SharedPreferences {
         return try {
             EncryptedSharedPreferences.create(
@@ -188,5 +197,6 @@ class AuthRepository @Inject constructor(
         private const val KEY_USERNAME = "cached_username"
         private const val KEY_DISPLAY_NAME = "cached_display_name"
         private const val KEY_AVATAR = "cached_avatar"
+        private const val KEY_PLAYBACK_SPEED = "playback_speed"
     }
 }

--- a/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
@@ -1049,6 +1049,12 @@ class AudioPlaybackService : MediaLibraryService() {
             }
 
             exoPlayer.play()
+
+            // Restore saved playback speed
+            val savedSpeed = authRepository.getPlaybackSpeed()
+            exoPlayer.setPlaybackSpeed(savedSpeed)
+            playerState.updatePlaybackSpeed(savedSpeed)
+
             startProgressSync()
 
             // Start foreground with our custom MediaStyle notification
@@ -1103,6 +1109,7 @@ class AudioPlaybackService : MediaLibraryService() {
     fun setPlaybackSpeed(speed: Float) {
         player?.setPlaybackSpeed(speed)
         playerState.updatePlaybackSpeed(speed)
+        authRepository.savePlaybackSpeed(speed)
     }
 
     fun setSleepTimer(minutes: Int) {


### PR DESCRIPTION
## Summary
- Playback speed now persists across app restarts and book changes
- Speed saved to SharedPreferences when user changes it
- Speed restored when playback starts

## Test plan
- [ ] Set playback speed to 1.5x
- [ ] Switch to another book - verify speed is still 1.5x
- [ ] Kill app and reopen - verify speed is still 1.5x

🤖 Generated with [Claude Code](https://claude.com/claude-code)