### PR TITLE
fix: prefill URL field with https:// on login screen

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginScreen.kt
@@ -102,7 +102,7 @@ fun LoginScreen(
                 value = serverUrl,
                 onValueChange = { viewModel.updateServerUrl(it) },
                 label = { Text("Server URL", color = SapphoTextLight) },
-                placeholder = { Text("http://192.168.1.100:3002", color = SapphoTextMuted) },
+                placeholder = { Text("https://your-server.com", color = SapphoTextMuted) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(8.dp),

--- a/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginViewModel.kt
@@ -20,7 +20,7 @@ class LoginViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<LoginUiState>(LoginUiState.Initial)
     val uiState: StateFlow<LoginUiState> = _uiState
 
-    private val _serverUrl = MutableStateFlow(authRepository.getServerUrlSync() ?: "")
+    private val _serverUrl = MutableStateFlow(authRepository.getServerUrlSync() ?: "https://")
     val serverUrl: StateFlow<String> = _serverUrl
 
     fun updateServerUrl(url: String) {

--- a/app/src/test/java/com/sappho/audiobooks/presentation/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/presentation/login/LoginViewModelTest.kt
@@ -161,13 +161,27 @@ class LoginViewModelTest {
     fun `updateServerUrl updates viewModel state`() = runTest {
         // Given
         val newUrl = "https://new.sappho.com"
-        
+
         // When
         viewModel.updateServerUrl(newUrl)
-        
+
         // Then - should update the state but NOT save to repository yet
         // (saving happens during login)
         assertThat(viewModel.serverUrl.value).isEqualTo(newUrl)
         verify(exactly = 0) { authRepository.saveServerUrl(any()) }
+    }
+
+    @Test
+    fun `serverUrl defaults to https prefix when no saved URL`() = runTest {
+        // Given
+        val api = mockk<SapphoApi>(relaxed = true)
+        val authRepository = mockk<AuthRepository>(relaxed = true)
+        every { authRepository.getServerUrlSync() } returns null
+
+        // When
+        val viewModel = LoginViewModel(api, authRepository)
+
+        // Then
+        assertThat(viewModel.serverUrl.value).isEqualTo("https://")
     }
 }


### PR DESCRIPTION
## Summary
- Default server URL to "https://" when no saved URL exists
- Prevents keyboards from auto-inserting unwanted characters
- Updated placeholder to show https example

## Test plan
- [ ] Build completes successfully
- [ ] Fresh install shows "https://" prefilled in URL field
- [ ] Keyboard shows URL-appropriate layout (no auto-corrections)
- [ ] Existing users with saved URL still see their saved URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)