### PR TITLE
feat: animate download button from progress ring to checkmark

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 19
-        versionName = "0.9.1"
+        versionCode = 20
+        versionName = "0.9.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
@@ -1,6 +1,8 @@
 package com.sappho.audiobooks.presentation.detail
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -818,14 +820,10 @@ fun AudiobookDetailScreen(
                                         .height(48.dp),
                                     colors = ButtonDefaults.buttonColors(
                                         containerColor = when {
-                                            isDownloading -> SapphoInfo.copy(alpha = 0.15f)
-                                            isDownloaded -> SapphoSuccess.copy(alpha = 0.15f)
                                             hasDownloadError -> SapphoError.copy(alpha = 0.15f)
                                             else -> SapphoInfo.copy(alpha = 0.15f)
                                         },
                                         contentColor = when {
-                                            isDownloading -> LegacyBluePale
-                                            isDownloaded -> LegacyGreenPale
                                             hasDownloadError -> LegacyRedLight
                                             else -> LegacyBluePale
                                         }
@@ -833,25 +831,51 @@ fun AudiobookDetailScreen(
                                     shape = RoundedCornerShape(12.dp),
                                     border = BorderStroke(1.dp, Color.White.copy(alpha = 0.1f))
                                 ) {
-                                    when {
-                                        isDownloading -> {
-                                            CircularProgressIndicator(
-                                                progress = downloadProgress,
-                                                modifier = Modifier.size(16.dp),
-                                                color = LegacyBluePale,
-                                                strokeWidth = 2.dp
-                                            )
-                                            Spacer(modifier = Modifier.width(8.dp))
-                                        }
-                                        hasDownloadError -> {
-                                            Icon(
-                                                imageVector = Icons.Default.Refresh,
-                                                contentDescription = null,
-                                                modifier = Modifier.size(16.dp)
-                                            )
-                                            Spacer(modifier = Modifier.width(8.dp))
+                                    // Animated icon: progress ring -> checkmark
+                                    Crossfade(
+                                        targetState = when {
+                                            isDownloading -> "downloading"
+                                            isDownloaded -> "downloaded"
+                                            hasDownloadError -> "error"
+                                            else -> "idle"
+                                        },
+                                        animationSpec = tween(300),
+                                        label = "download_icon"
+                                    ) { state ->
+                                        when (state) {
+                                            "downloading" -> {
+                                                CircularProgressIndicator(
+                                                    progress = { downloadProgress },
+                                                    modifier = Modifier.size(16.dp),
+                                                    color = LegacyBluePale,
+                                                    strokeWidth = 2.dp
+                                                )
+                                            }
+                                            "downloaded" -> {
+                                                Icon(
+                                                    imageVector = Icons.Default.Check,
+                                                    contentDescription = null,
+                                                    modifier = Modifier.size(16.dp),
+                                                    tint = SapphoSuccess
+                                                )
+                                            }
+                                            "error" -> {
+                                                Icon(
+                                                    imageVector = Icons.Default.Refresh,
+                                                    contentDescription = null,
+                                                    modifier = Modifier.size(16.dp)
+                                                )
+                                            }
+                                            else -> {
+                                                Icon(
+                                                    imageVector = Icons.Default.Download,
+                                                    contentDescription = null,
+                                                    modifier = Modifier.size(16.dp)
+                                                )
+                                            }
                                         }
                                     }
+                                    Spacer(modifier = Modifier.width(8.dp))
                                     Text(
                                         text = when {
                                             isDownloading -> {


### PR DESCRIPTION
## Summary
- Progress ring shows during download with percentage
- Crossfade animation to green checkmark when download completes
- Keep consistent blue button color (removed green background on complete)
- Show download icon in idle state

## Test plan
- [ ] Build completes successfully
- [ ] Start a download - progress ring with percentage appears
- [ ] Complete download - ring animates to green checkmark
- [ ] Button stays blue (not green) when downloaded
- [ ] Tap downloaded button - shows delete dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)