### PR TITLE
fix: check for updates on app resume instead of just launch

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 20
-        versionName = "0.9.2"
+        versionCode = 21
+        versionName = "0.9.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/MainActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/MainActivity.kt
@@ -23,13 +23,16 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var inAppUpdateManager: InAppUpdateManager
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        // Check for app updates
+    override fun onResume() {
+        super.onResume()
+        // Check for app updates every time app comes to foreground
         lifecycleScope.launch {
             inAppUpdateManager.checkForUpdate()
         }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
 
         // Get navigation extras from intent (e.g., from PlayerActivity)
         val navigateTo = intent.getStringExtra("NAVIGATE_TO")


### PR DESCRIPTION
## Summary
- Move update check from `onCreate` to `onResume`
- Now checks for updates every time app comes to foreground
- User no longer needs to fully close and reopen app to see update prompt

## Test plan
- [ ] Build completes successfully
- [ ] Open app - no update prompt (already on latest)
- [ ] Background the app, publish new version, return to app - update prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)