### PR TITLE
fix: use immediate update flow to force app restart

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 21
-        versionName = "0.9.3"
+        versionCode = 22
+        versionName = "0.9.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/data/update/InAppUpdateManager.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/update/InAppUpdateManager.kt
@@ -33,11 +33,11 @@ class InAppUpdateManager @Inject constructor(
             appUpdateInfo = info
 
             val isUpdateAvailable = info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
-            val isFlexibleAllowed = info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
+            val isImmediateAllowed = info.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
 
-            _updateAvailable.value = isUpdateAvailable && isFlexibleAllowed
+            _updateAvailable.value = isUpdateAvailable && isImmediateAllowed
 
-            Log.d(TAG, "Update check: available=$isUpdateAvailable, flexibleAllowed=$isFlexibleAllowed")
+            Log.d(TAG, "Update check: available=$isUpdateAvailable, immediateAllowed=$isImmediateAllowed")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to check for update", e)
             _updateAvailable.value = false
@@ -54,7 +54,7 @@ class InAppUpdateManager @Inject constructor(
             appUpdateManager.startUpdateFlowForResult(
                 info,
                 activity,
-                AppUpdateOptions.defaultOptions(AppUpdateType.FLEXIBLE),
+                AppUpdateOptions.defaultOptions(AppUpdateType.IMMEDIATE),
                 UPDATE_REQUEST_CODE
             )
         } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- Change from `FLEXIBLE` to `IMMEDIATE` update type
- IMMEDIATE shows full-screen Play Store update UI
- Forces update and automatically restarts app when complete
- User can't dismiss and continue using old version

## Test plan
- [ ] Build completes successfully
- [ ] Tap "Update Now" - full-screen update UI appears
- [ ] Update downloads and app restarts automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)