### PR TITLE
fix: fall back to flexible update if immediate not allowed

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 22
-        versionName = "0.9.4"
+        versionCode = 23
+        versionName = "0.9.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- Check both IMMEDIATE and FLEXIBLE update types
- Prefer IMMEDIATE, fall back to FLEXIBLE if not allowed
- Added detailed logging for debugging
- Fixes issue where updates weren't showing because IMMEDIATE wasn't allowed

## Test plan
- [ ] Build completes successfully
- [ ] Update prompt appears when update is available
- [ ] Check logcat for update type being used

🤖 Generated with [Claude Code](https://claude.com/claude-code)