### PR TITLE
feat: modernize downloads dialog with sleek design

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 23
-        versionName = "0.9.5"
+        versionCode = 24
+        versionName = "0.9.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- Modern card-based design with cover images
- Stats bar showing total books and storage used
- Clean empty state with icon
- Author and file size displayed
- Better spacing and rounded corners

## Test plan
- [ ] Build completes successfully
- [ ] Open downloads from avatar menu
- [ ] Empty state shows when no downloads
- [ ] Downloaded books show with cover, title, author, size
- [ ] Delete button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)