### PR TITLE
feat: move chapter button to overflow menu, download button next to play

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 25
-        versionName = "0.9.7"
+        versionCode = 26
+        versionName = "0.9.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- Move chapter button from separate row to overflow menu (shows "X Chapters" with list icon)
- Add compact download icon button (48dp) next to play button (56dp) for visual hierarchy
- Download icon states: down arrow (idle), progress ring (downloading), checkmark (downloaded), refresh (error)
- Removes redundant chapters/download row for cleaner layout

## Test plan
- [ ] Open a multi-file audiobook (has chapters) and verify chapters option appears in overflow menu
- [ ] Tap overflow menu → "X Chapters" opens chapter list dialog
- [ ] Verify download button appears next to play button with proper sizing (play is larger)
- [ ] Test download flow: tap download icon, see progress ring, then checkmark when complete
- [ ] Tap downloaded (checkmark) icon shows delete download confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)