### PR TITLE
feat: add tablet and foldable adaptive layouts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 26
-        versionName = "0.9.8"
+        versionCode = 27
+        versionName = "0.9.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -106,6 +106,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material3:material3-window-size-class")
     implementation("androidx.compose.material:material-icons-extended")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/app/src/main/java/com/sappho/audiobooks/presentation/MainActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/MainActivity.kt
@@ -6,6 +6,9 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -16,6 +19,7 @@ import com.sappho.audiobooks.presentation.components.UpdateAvailableDialog
 import com.sappho.audiobooks.presentation.components.UpdateDownloadingDialog
 import com.sappho.audiobooks.presentation.components.UpdateReadyDialog
 import com.sappho.audiobooks.presentation.components.UpdateFailedDialog
+import com.sappho.audiobooks.presentation.theme.LocalWindowSizeClass
 import com.sappho.audiobooks.presentation.theme.SapphoTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -44,10 +48,14 @@ class MainActivity : ComponentActivity() {
         val series = intent.getStringExtra("SERIES")
 
         setContent {
-            SapphoTheme {
-                val updateState by inAppUpdateManager.updateState.collectAsState()
+            @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+            val windowSizeClass = calculateWindowSizeClass(this)
 
-                Surface(
+            CompositionLocalProvider(LocalWindowSizeClass provides windowSizeClass) {
+                SapphoTheme {
+                    val updateState by inAppUpdateManager.updateState.collectAsState()
+
+                    Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
@@ -96,6 +104,7 @@ class MainActivity : ComponentActivity() {
                         else -> { /* No dialog for None or Installing states */ }
                     }
                 }
+            }
             }
         }
     }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionDetailScreen.kt
@@ -229,10 +229,10 @@ fun CollectionDetailScreen(
                 }
                 else -> {
                     LazyVerticalGrid(
-                        columns = GridCells.Fixed(2),
-                        contentPadding = PaddingValues(16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                        columns = AdaptiveGrid.audiobookGrid,
+                        contentPadding = PaddingValues(AdaptiveSpacing.screenPadding),
+                        horizontalArrangement = Arrangement.spacedBy(AdaptiveSpacing.gridSpacing),
+                        verticalArrangement = Arrangement.spacedBy(AdaptiveSpacing.gridSpacing),
                         modifier = Modifier.fillMaxSize()
                     ) {
                         items(collection?.books ?: emptyList()) { book ->

--- a/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionsScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionsScreen.kt
@@ -212,10 +212,10 @@ fun CollectionsScreen(
                 }
                 else -> {
                     LazyVerticalGrid(
-                        columns = GridCells.Fixed(2),
-                        contentPadding = PaddingValues(16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                        columns = AdaptiveGrid.categoryGrid,
+                        contentPadding = PaddingValues(AdaptiveSpacing.screenPadding),
+                        horizontalArrangement = Arrangement.spacedBy(AdaptiveSpacing.gridSpacing),
+                        verticalArrangement = Arrangement.spacedBy(AdaptiveSpacing.gridSpacing),
                         modifier = Modifier.fillMaxSize()
                     ) {
                         items(collections) { collection ->

--- a/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
@@ -197,7 +197,7 @@ fun HomeScreen(
                         serverUrl = serverUrl,
                         onAudiobookClick = onAudiobookClick,
                         onToggleFavorite = { id -> viewModel.toggleFavorite(id) },
-                        cardSize = 180.dp,
+                        cardSize = AdaptiveCardSize.large,
                         titleSize = 18.sp
                     )
                 }
@@ -222,7 +222,7 @@ fun HomeScreen(
                                 viewModel.loadCollectionsForBook(id)
                                 showCollectionDialog = true
                             },
-                            cardSize = 180.dp,
+                            cardSize = AdaptiveCardSize.large,
                             titleSize = 20.sp
                         )
                     }
@@ -281,7 +281,7 @@ fun HomeScreen(
                                 viewModel.loadCollectionsForBook(id)
                                 showCollectionDialog = true
                             },
-                            cardSize = 120.dp,
+                            cardSize = AdaptiveCardSize.small,
                             titleSize = 14.sp,
                             showCompletedCheckmark = false
                         )

--- a/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
@@ -2944,11 +2944,11 @@ fun AllBooksView(
                 }
             }
 
-            // Books Grid
+            // Books Grid (adaptive for tablets)
             LazyVerticalGrid(
-                columns = GridCells.Fixed(3),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                columns = AdaptiveGrid.libraryGrid,
+                horizontalArrangement = Arrangement.spacedBy(AdaptiveSpacing.gridSpacing),
+                verticalArrangement = Arrangement.spacedBy(AdaptiveSpacing.gridSpacing),
                 modifier = Modifier.fillMaxWidth()
             ) {
                 items(sortedBooks.size) { index ->

--- a/app/src/main/java/com/sappho/audiobooks/presentation/readinglist/ReadingListScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/readinglist/ReadingListScreen.kt
@@ -118,12 +118,12 @@ fun ReadingListScreen(
             }
         } else {
             LazyVerticalGrid(
-                columns = GridCells.Fixed(3),
+                columns = AdaptiveGrid.libraryGrid,
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+                    .padding(horizontal = AdaptiveSpacing.screenPadding),
+                horizontalArrangement = Arrangement.spacedBy(AdaptiveSpacing.gridSpacing),
+                verticalArrangement = Arrangement.spacedBy(AdaptiveSpacing.gridSpacing),
                 contentPadding = PaddingValues(bottom = 16.dp)
             ) {
                 items(books) { book ->

--- a/app/src/main/java/com/sappho/audiobooks/presentation/theme/AdaptiveLayout.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/theme/AdaptiveLayout.kt
@@ -1,0 +1,234 @@
+package com.sappho.audiobooks.presentation.theme
+
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Local composition for WindowSizeClass to be provided at the app level
+ */
+val LocalWindowSizeClass = compositionLocalOf<WindowSizeClass?> { null }
+
+/**
+ * Screen size categories for adaptive layouts
+ */
+enum class ScreenSize {
+    COMPACT,    // Phone portrait (<600dp)
+    MEDIUM,     // Phone landscape, small tablets, foldables (600-840dp)
+    EXPANDED    // Tablets (>840dp)
+}
+
+/**
+ * Get the current screen size category based on window width
+ */
+@Composable
+fun rememberScreenSize(): ScreenSize {
+    val windowSizeClass = LocalWindowSizeClass.current
+
+    return if (windowSizeClass != null) {
+        when (windowSizeClass.widthSizeClass) {
+            WindowWidthSizeClass.Compact -> ScreenSize.COMPACT
+            WindowWidthSizeClass.Medium -> ScreenSize.MEDIUM
+            WindowWidthSizeClass.Expanded -> ScreenSize.EXPANDED
+            else -> ScreenSize.COMPACT
+        }
+    } else {
+        // Fallback to configuration-based detection
+        val configuration = LocalConfiguration.current
+        when {
+            configuration.screenWidthDp < 600 -> ScreenSize.COMPACT
+            configuration.screenWidthDp < 840 -> ScreenSize.MEDIUM
+            else -> ScreenSize.EXPANDED
+        }
+    }
+}
+
+/**
+ * Check if the current layout is in landscape orientation
+ */
+@Composable
+fun isLandscape(): Boolean {
+    val configuration = LocalConfiguration.current
+    return configuration.screenWidthDp > configuration.screenHeightDp
+}
+
+/**
+ * Adaptive grid columns based on screen size
+ * Uses Adaptive cells with minimum size for responsive grids
+ */
+object AdaptiveGrid {
+    /**
+     * Grid cells for audiobook cards (covers)
+     * Minimum size ensures cards aren't too small on any device
+     */
+    val audiobookGrid: GridCells
+        @Composable
+        get() {
+            val screenSize = rememberScreenSize()
+            return when (screenSize) {
+                ScreenSize.COMPACT -> GridCells.Fixed(2)
+                ScreenSize.MEDIUM -> GridCells.Adaptive(minSize = 140.dp)
+                ScreenSize.EXPANDED -> GridCells.Adaptive(minSize = 160.dp)
+            }
+        }
+
+    /**
+     * Grid cells for library view (can show more items)
+     */
+    val libraryGrid: GridCells
+        @Composable
+        get() {
+            val screenSize = rememberScreenSize()
+            return when (screenSize) {
+                ScreenSize.COMPACT -> GridCells.Fixed(3)
+                ScreenSize.MEDIUM -> GridCells.Adaptive(minSize = 120.dp)
+                ScreenSize.EXPANDED -> GridCells.Adaptive(minSize = 140.dp)
+            }
+        }
+
+    /**
+     * Grid cells for category cards (larger items)
+     */
+    val categoryGrid: GridCells
+        @Composable
+        get() {
+            val screenSize = rememberScreenSize()
+            return when (screenSize) {
+                ScreenSize.COMPACT -> GridCells.Fixed(2)
+                ScreenSize.MEDIUM -> GridCells.Fixed(3)
+                ScreenSize.EXPANDED -> GridCells.Adaptive(minSize = 200.dp)
+            }
+        }
+
+    /**
+     * Get fixed column count for screens that need exact column numbers
+     */
+    @Composable
+    fun getColumnCount(baseColumns: Int = 2): Int {
+        val screenSize = rememberScreenSize()
+        return when (screenSize) {
+            ScreenSize.COMPACT -> baseColumns
+            ScreenSize.MEDIUM -> baseColumns + 1
+            ScreenSize.EXPANDED -> baseColumns + 2
+        }
+    }
+}
+
+/**
+ * Adaptive spacing and padding values
+ */
+object AdaptiveSpacing {
+    /**
+     * Horizontal padding for screen content
+     */
+    val screenPadding: Dp
+        @Composable
+        get() {
+            val screenSize = rememberScreenSize()
+            return when (screenSize) {
+                ScreenSize.COMPACT -> 16.dp
+                ScreenSize.MEDIUM -> 24.dp
+                ScreenSize.EXPANDED -> 32.dp
+            }
+        }
+
+    /**
+     * Grid item spacing
+     */
+    val gridSpacing: Dp
+        @Composable
+        get() {
+            val screenSize = rememberScreenSize()
+            return when (screenSize) {
+                ScreenSize.COMPACT -> 8.dp
+                ScreenSize.MEDIUM -> 12.dp
+                ScreenSize.EXPANDED -> 16.dp
+            }
+        }
+
+    /**
+     * Section spacing (between content sections)
+     */
+    val sectionSpacing: Dp
+        @Composable
+        get() {
+            val screenSize = rememberScreenSize()
+            return when (screenSize) {
+                ScreenSize.COMPACT -> 24.dp
+                ScreenSize.MEDIUM -> 32.dp
+                ScreenSize.EXPANDED -> 40.dp
+            }
+        }
+}
+
+/**
+ * Adaptive card sizes for horizontal scrolling sections
+ */
+object AdaptiveCardSize {
+    /**
+     * Large card size (e.g., Continue Listening)
+     */
+    val large: Dp
+        @Composable
+        get() {
+            val screenSize = rememberScreenSize()
+            return when (screenSize) {
+                ScreenSize.COMPACT -> 160.dp
+                ScreenSize.MEDIUM -> 180.dp
+                ScreenSize.EXPANDED -> 200.dp
+            }
+        }
+
+    /**
+     * Standard card size (e.g., Recently Added)
+     */
+    val standard: Dp
+        @Composable
+        get() {
+            val screenSize = rememberScreenSize()
+            return when (screenSize) {
+                ScreenSize.COMPACT -> 130.dp
+                ScreenSize.MEDIUM -> 150.dp
+                ScreenSize.EXPANDED -> 170.dp
+            }
+        }
+
+    /**
+     * Small card size (e.g., Listen Again)
+     */
+    val small: Dp
+        @Composable
+        get() {
+            val screenSize = rememberScreenSize()
+            return when (screenSize) {
+                ScreenSize.COMPACT -> 110.dp
+                ScreenSize.MEDIUM -> 130.dp
+                ScreenSize.EXPANDED -> 150.dp
+            }
+        }
+}
+
+/**
+ * Determine if navigation rail should be shown instead of top bar
+ */
+@Composable
+fun shouldShowNavigationRail(): Boolean {
+    val screenSize = rememberScreenSize()
+    return screenSize == ScreenSize.EXPANDED ||
+           (screenSize == ScreenSize.MEDIUM && isLandscape())
+}
+
+/**
+ * Determine if detail screen should use two-column layout
+ */
+@Composable
+fun shouldUseTwoColumnDetail(): Boolean {
+    val screenSize = rememberScreenSize()
+    return screenSize == ScreenSize.EXPANDED ||
+           (screenSize == ScreenSize.MEDIUM && isLandscape())
+}


### PR DESCRIPTION
## Summary
- Add WindowSizeClass support for detecting device/window size
- Create `AdaptiveLayout.kt` utility with:
  - `ScreenSize` enum (COMPACT, MEDIUM, EXPANDED)
  - `AdaptiveGrid` object for responsive grid columns
  - `AdaptiveSpacing` for responsive padding/spacing
  - `AdaptiveCardSize` for responsive card dimensions
- Update all grid screens to use adaptive columns:
  - LibraryScreen: 3 fixed → adaptive (120-140dp min)
  - CollectionsScreen: 2 fixed → adaptive categories
  - CollectionDetailScreen: 2 fixed → adaptive audiobook grid
  - ReadingListScreen: 3 fixed → adaptive library grid
- Update HomeScreen card sizes to scale with screen width

## Device Support
| Device | Width Class | Grid Behavior |
|--------|-------------|---------------|
| Phone portrait | Compact (<600dp) | Fixed 2-3 columns |
| Phone landscape | Medium (600-840dp) | Adaptive min 120dp |
| Z Fold 6 unfolded | Medium (~840dp) | Adaptive min 120dp |
| Tablets | Expanded (>840dp) | Adaptive min 140-160dp |

## Test plan
- [ ] Test on phone in portrait - should look same as before
- [ ] Test on phone in landscape - grids should show more columns
- [ ] Test on tablet/large screen - grids fill space properly
- [ ] Test Z Fold 6 inner display (if available) - adapts to medium size

🤖 Generated with [Claude Code](https://claude.com/claude-code)