### PR TITLE
fix: mini player showing wrong position when resuming book

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerViewModel.kt
@@ -63,10 +63,12 @@ class PlayerViewModel @Inject constructor(
             if (book == null) {
                 val downloadedBook = downloadManager.getDownloadedBook(audiobookId)
                 book = downloadedBook?.audiobook
-                // If we're using downloaded data and no position was passed, use the stored progress
-                if (actualStartPosition == 0 && book?.progress != null) {
-                    actualStartPosition = book.progress!!.position
-                }
+            }
+
+            // If no explicit position was passed, use the book's saved progress
+            // This applies whether we got the book from server or from downloaded data
+            if (actualStartPosition == 0 && book?.progress != null) {
+                actualStartPosition = book.progress!!.position
             }
 
             _audiobook.value = book


### PR DESCRIPTION
## Summary
Fixes #173 - Mini player shows wrong position when resuming a book with progress.

## Root Cause
The progress check logic only ran when the server request **failed** (fallback to downloaded data), not when it **succeeded**. So when the server returned the book with progress data, the position defaulted to 0.

## Fix
Moved the progress check outside the `if (book == null)` fallback block so it applies whether we got the book from server or from downloaded data.

## Test plan
- [ ] Play a book, make progress (e.g., 30 min), stop playback
- [ ] Close app completely
- [ ] Reopen app, navigate to the book
- [ ] Tap Play immediately (don't wait for progress to load)
- [ ] Verify mini player shows correct position
- [ ] Verify audio plays from correct position

🤖 Generated with [Claude Code](https://claude.com/claude-code)