### PR TITLE
fix: prevent sync error banner from persisting after dismissal

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 30
-        versionName = "0.9.12"
+        versionCode = 31
+        versionName = "0.9.13"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- Fix bug where sync error banner would persist even after being dismissed by the user
- Track last processed WorkManager work run ID to avoid re-handling the same state on every LiveData emission
- Bump version to 0.9.13 (versionCode 31)

## Problem
The sync status observer was re-processing the same WorkManager state every time LiveData emitted. This meant that if a user dismissed a sync error, it could reappear immediately because the observer would re-set it based on the (unchanged) work state.

## Solution
Track the `lastProcessedWorkRunId` and only process SUCCEEDED/FAILED/CANCELLED states once per unique work run. This ensures that dismissing an error actually keeps it dismissed until a new sync operation produces a new result.

## Test plan
- [ ] Trigger a sync error condition (e.g., network failure)
- [ ] Dismiss the error using the dismiss button
- [ ] Verify the error does not reappear
- [ ] Verify normal sync operations still show/clear banners appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)