### PR TITLE
fix: stop treating cancelled sync jobs as errors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 31
-        versionName = "0.9.13"
+        versionCode = 32
+        versionName = "0.9.14"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- Stop showing "Sync was cancelled" error when WorkManager replaces an old sync job (expected behavior with `ExistingWorkPolicy.REPLACE`)
- Clear stale errors when triggering a new sync attempt
- Remove unused `combine` import
- Bump version to 0.9.14 (versionCode 32)

## Root cause
The sync error banner was persisting on the home screen because:
1. `ProgressSyncWorker` uses `ExistingWorkPolicy.REPLACE` - when a new sync is triggered, the old job gets CANCELLED
2. The observer was treating CANCELLED as an error, showing "Sync was cancelled"
3. This error could persist even though sync was actually working fine via direct API calls

## Test plan
- [ ] Verify sync error banner no longer appears when sync is working
- [ ] Verify actual sync failures still show error banners
- [ ] Verify dismissing an error keeps it dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)