### PR TITLE
fix: ignore stale WorkManager sync errors from previous sessions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 32
-        versionName = "0.9.14"
+        versionCode = 33
+        versionName = "0.9.15"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- Skip error processing on the first WorkManager observation (app launch) to avoid showing stale errors from previous sessions
- Only show sync errors for failures that occur during the current app session
- Bump version to 0.9.15 (versionCode 33)

## Root cause
When updating via Play Store (which preserves app data), WorkManager's database retains the last work state. If a previous sync had failed or been cancelled, the observer would read this stale state on startup and immediately show the error banner - even though sync was working fine.

The debug install didn't have this issue because it required a full uninstall (clearing all data) due to signature mismatch.

## Test plan
- [ ] Update from Play Store - verify no stale sync error on launch
- [ ] Trigger actual sync failure during session - verify error shows
- [ ] Normal sync operation - verify no error banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)