### PR TITLE
Fix cover display and server URL trimming

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 36
-        versionName = "0.9.18"
+        versionCode = 37
+        versionName = "0.9.19"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/repository/AuthRepository.kt
@@ -54,12 +54,12 @@ class AuthRepository @Inject constructor(
     }
 
     fun saveServerUrl(url: String) {
-        securePrefs.edit().putString(KEY_SERVER_URL, url).apply()
+        securePrefs.edit().putString(KEY_SERVER_URL, url.trim().trimEnd('/')).apply()
         _isAuthenticated.value = getTokenSync() != null && getServerUrlSync() != null
     }
 
     fun getServerUrlSync(): String? {
-        return securePrefs.getString(KEY_SERVER_URL, null)
+        return securePrefs.getString(KEY_SERVER_URL, null)?.trim()?.trimEnd('/')
     }
 
     fun hasServerUrl(): Boolean {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionDetailScreen.kt
@@ -364,7 +364,7 @@ private fun CollectionBookItem(
                     model = com.sappho.audiobooks.util.buildCoverUrl(serverUrl, book.id, com.sappho.audiobooks.util.COVER_WIDTH_THUMBNAIL),
                     contentDescription = book.title,
                     modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop
+                    contentScale = ContentScale.Fit
                 )
             } else {
                 Box(

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
@@ -358,7 +358,7 @@ fun AudiobookDetailScreen(
                                         model = coverUrl,
                                         contentDescription = book.title,
                                         modifier = Modifier.fillMaxSize(),
-                                        contentScale = ContentScale.Crop
+                                        contentScale = ContentScale.Fit
                                     )
                                 } else {
                                     // Show placeholder when no cover available

--- a/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
@@ -496,7 +496,7 @@ fun AudiobookCard(
                             .build(),
                         contentDescription = book.title,
                         modifier = Modifier.fillMaxSize(),
-                        contentScale = ContentScale.Crop
+                        contentScale = ContentScale.Fit
                     )
                 }
 

--- a/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
@@ -732,7 +732,7 @@ fun SeriesListCard(
                             model = com.sappho.audiobooks.util.buildCoverUrl(serverUrl, book.id, com.sappho.audiobooks.util.COVER_WIDTH_THUMBNAIL),
                             contentDescription = null,
                             modifier = Modifier.fillMaxSize(),
-                            contentScale = ContentScale.Crop
+                            contentScale = ContentScale.Fit
                         )
                     }
                 }
@@ -1063,7 +1063,7 @@ fun AuthorListCard(
                                 model = com.sappho.audiobooks.util.buildCoverUrl(serverUrl, book.id, com.sappho.audiobooks.util.COVER_WIDTH_THUMBNAIL),
                                 contentDescription = null,
                                 modifier = Modifier.fillMaxSize(),
-                                contentScale = ContentScale.Crop
+                                contentScale = ContentScale.Fit
                             )
                         }
                     }
@@ -1262,7 +1262,7 @@ fun GenreListCard(
                                 model = com.sappho.audiobooks.util.buildCoverUrl(serverUrl, book.id, com.sappho.audiobooks.util.COVER_WIDTH_THUMBNAIL),
                                 contentDescription = null,
                                 modifier = Modifier.fillMaxSize(),
-                                contentScale = ContentScale.Crop
+                                contentScale = ContentScale.Fit
                             )
                         }
                     }
@@ -2273,7 +2273,7 @@ fun AuthorBookCard(
                     model = com.sappho.audiobooks.util.buildCoverUrl(serverUrl, book.id, com.sappho.audiobooks.util.COVER_WIDTH_THUMBNAIL),
                     contentDescription = book.title,
                     modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop
+                    contentScale = ContentScale.Fit
                 )
             } else {
                 Box(
@@ -2657,7 +2657,7 @@ fun GenreBookGridItem(
                     model = com.sappho.audiobooks.util.buildCoverUrl(serverUrl, book.id, com.sappho.audiobooks.util.COVER_WIDTH_THUMBNAIL),
                     contentDescription = book.title,
                     modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop
+                    contentScale = ContentScale.Fit
                 )
             } else {
                 Box(
@@ -2762,7 +2762,7 @@ fun BookGridItem(
                 model = com.sappho.audiobooks.util.buildCoverUrl(serverUrl, book.id, com.sappho.audiobooks.util.COVER_WIDTH_THUMBNAIL),
                 contentDescription = book.title,
                 modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.Fit
             )
         } else {
             Box(
@@ -3223,7 +3223,7 @@ fun SelectableBookGridItem(
                 model = com.sappho.audiobooks.util.buildCoverUrl(serverUrl, book.id, com.sappho.audiobooks.util.COVER_WIDTH_THUMBNAIL),
                 contentDescription = book.title,
                 modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.Fit
             )
         } else {
             Box(

--- a/app/src/main/java/com/sappho/audiobooks/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/main/MainScreen.kt
@@ -676,7 +676,7 @@ fun MainScreen(
                                         modifier = Modifier
                                             .size(56.dp)
                                             .clip(RoundedCornerShape(8.dp)),
-                                        contentScale = ContentScale.Crop
+                                        contentScale = ContentScale.Fit
                                     )
 
                                     Spacer(modifier = Modifier.width(12.dp))

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/MinimizedPlayerBar.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/MinimizedPlayerBar.kt
@@ -216,7 +216,7 @@ fun MinimizedPlayerBar(
                                 model = com.sappho.audiobooks.util.buildCoverUrl(serverUrl, book.id, com.sappho.audiobooks.util.COVER_WIDTH_THUMBNAIL),
                                 contentDescription = book.title,
                                 modifier = Modifier.fillMaxSize(),
-                                contentScale = ContentScale.Crop
+                                contentScale = ContentScale.Fit
                             )
                         } else {
                             Box(

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
@@ -641,7 +641,7 @@ fun PlayerScreen(
                                 model = com.sappho.audiobooks.util.buildCoverUrl(serverUrl!!, book.id, com.sappho.audiobooks.util.COVER_WIDTH_DETAIL),
                                 contentDescription = book.title,
                                 modifier = Modifier.fillMaxSize(),
-                                contentScale = ContentScale.Crop
+                                contentScale = ContentScale.Fit
                             )
                         } else {
                             Box(

--- a/app/src/main/java/com/sappho/audiobooks/presentation/readinglist/ReadingListScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/readinglist/ReadingListScreen.kt
@@ -158,7 +158,7 @@ fun ReadingListBookItem(
                     model = com.sappho.audiobooks.util.buildCoverUrl(serverUrl, book.id, com.sappho.audiobooks.util.COVER_WIDTH_THUMBNAIL),
                     contentDescription = book.title,
                     modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop
+                    contentScale = ContentScale.Fit
                 )
             } else {
                 Box(

--- a/app/src/main/java/com/sappho/audiobooks/presentation/search/SearchScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/search/SearchScreen.kt
@@ -247,7 +247,7 @@ private fun SearchResultItem(
                     model = com.sappho.audiobooks.util.buildCoverUrl(serverUrl, book.id, com.sappho.audiobooks.util.COVER_WIDTH_THUMBNAIL),
                     contentDescription = book.title,
                     modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop
+                    contentScale = ContentScale.Fit
                 )
             } else {
                 Box(


### PR DESCRIPTION
## Summary
- Use `ContentScale.Fit` for all cover images so covers show in full with letterboxing instead of cropping
- Keep `ContentScale.Crop` for avatar images (fills circle properly)
- Trim whitespace and trailing slashes from stored server URL — a trailing space in the saved URL caused Coil to reject every cover request with `Invalid URL host: "sappho.bitstorm.ca "`
- Version bump: 0.9.19 (code 37)

## Test plan
- [ ] Open app — covers should display with letterboxing, not cropped
- [ ] Avatar in profile dropdown should fill the circle
- [ ] Verify covers load successfully (no "Invalid URL host" errors in logcat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)