### PR TITLE
Add Roku, AirPlay, and Kodi casting support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 37
-        versionName = "0.9.19"
+        versionCode = 38
+        versionName = "0.9.20"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <application
         android:name=".SapphoApplication"

--- a/app/src/main/java/com/sappho/audiobooks/cast/CastManager.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/CastManager.kt
@@ -1,0 +1,450 @@
+package com.sappho.audiobooks.cast
+
+import android.content.Context
+import android.net.wifi.WifiManager
+import android.util.Log
+import androidx.mediarouter.media.MediaRouter
+import com.sappho.audiobooks.cast.discovery.MdnsDiscovery
+import com.sappho.audiobooks.cast.discovery.SsdpDiscovery
+import com.sappho.audiobooks.cast.targets.AirPlayCastTarget
+import com.sappho.audiobooks.cast.targets.ChromecastTarget
+import com.sappho.audiobooks.cast.targets.KodiCastTarget
+import com.sappho.audiobooks.cast.targets.RokuCastTarget
+import com.sappho.audiobooks.data.repository.AuthRepository
+import com.sappho.audiobooks.domain.model.Audiobook
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Orchestrates casting across all supported protocols (Chromecast, Roku, Kodi, AirPlay).
+ * Manages device discovery, delegates playback to the active CastTarget, and exposes
+ * unified StateFlows for the UI layer.
+ */
+@Singleton
+class CastManager @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val castHelper: CastHelper
+) {
+    companion object {
+        private const val TAG = "CastManager"
+        private const val ROKU_SEARCH_TARGET = "roku:ecp"
+        private const val KODI_SEARCH_TARGET = "urn:schemas-upnp-org:device:MediaRenderer:1"
+        private const val AIRPLAY_SERVICE_TYPE = "_airplay._tcp."
+    }
+
+    // Local network HTTP client (no auth interceptor)
+    private val localHttpClient = OkHttpClient.Builder()
+        .connectTimeout(5, TimeUnit.SECONDS)
+        .readTimeout(10, TimeUnit.SECONDS)
+        .build()
+
+    // Protocol targets
+    private val chromecastTarget = ChromecastTarget(castHelper)
+    private val rokuTarget = RokuCastTarget(localHttpClient)
+    private val kodiTarget = KodiCastTarget(localHttpClient)
+    private val airPlayTarget = AirPlayCastTarget(localHttpClient)
+
+    // Discovery utilities
+    private val ssdpDiscovery = SsdpDiscovery()
+
+    // Active target
+    private var activeTarget: CastTarget? = null
+
+    // Discovered devices from all protocols
+    private val _discoveredDevices = MutableStateFlow<List<CastDevice>>(emptyList())
+    val discoveredDevices: StateFlow<List<CastDevice>> = _discoveredDevices
+
+    // Unified state (delegates to active target or defaults)
+    private val _isConnected = MutableStateFlow(false)
+    val isConnected: StateFlow<Boolean> = _isConnected
+
+    private val _isPlaying = MutableStateFlow(false)
+    val isPlaying: StateFlow<Boolean> = _isPlaying
+
+    private val _currentPosition = MutableStateFlow(0L)
+    val currentPosition: StateFlow<Long> = _currentPosition
+
+    private val _connectedDeviceName = MutableStateFlow<String?>(null)
+    val connectedDeviceName: StateFlow<String?> = _connectedDeviceName
+
+    private val _activeProtocol = MutableStateFlow<CastProtocol?>(null)
+    val activeProtocol: StateFlow<CastProtocol?> = _activeProtocol
+
+    private val scope = CoroutineScope(Dispatchers.Main)
+    private var discoveryJob: Job? = null
+    private var stateObserverJob: Job? = null
+    private var multicastLock: WifiManager.MulticastLock? = null
+
+    init {
+        // Observe Chromecast connection changes from CastHelper (it connects externally via route selection)
+        scope.launch {
+            castHelper.isConnected.collect { connected ->
+                if (connected && activeTarget == null) {
+                    // Chromecast connected externally (e.g., through route selection)
+                    activeTarget = chromecastTarget
+                    _activeProtocol.value = CastProtocol.CHROMECAST
+                    observeActiveTargetState()
+                } else if (!connected && activeTarget == chromecastTarget) {
+                    activeTarget = null
+                    _activeProtocol.value = null
+                    _isConnected.value = false
+                    _isPlaying.value = false
+                    _connectedDeviceName.value = null
+                }
+            }
+        }
+    }
+
+    fun initialize(context: Context) {
+        castHelper.initialize(context)
+    }
+
+    /**
+     * Start discovering devices across all supported protocols.
+     */
+    fun startDiscovery(context: Context) {
+        stopDiscovery()
+
+        // Acquire multicast lock for SSDP/mDNS
+        acquireMulticastLock(context)
+
+        // Start Chromecast discovery
+        chromecastTarget.startDiscovery(context)
+
+        discoveryJob = scope.launch {
+            val allDevices = mutableListOf<CastDevice>()
+
+            // Collect Chromecast routes as devices
+            launch {
+                chromecastTarget.getAvailableRoutes().collect { routes ->
+                    val chromecastDevices = routes.map { route ->
+                        CastDevice(
+                            id = "chromecast_${route.id}",
+                            name = route.name,
+                            protocol = CastProtocol.CHROMECAST,
+                            host = "",
+                            port = 0,
+                            extras = route
+                        )
+                    }
+                    updateDeviceList(CastProtocol.CHROMECAST, chromecastDevices)
+                }
+            }
+
+            // Discover Roku devices via SSDP
+            launch(Dispatchers.IO) {
+                try {
+                    ssdpDiscovery.discover(ROKU_SEARCH_TARGET, timeoutMs = 5000).collect { ssdpDevice ->
+                        val rokuDevice = CastDevice(
+                            id = "roku_${ssdpDevice.host}",
+                            name = ssdpDevice.friendlyName ?: "Roku (${ssdpDevice.host})",
+                            protocol = CastProtocol.ROKU,
+                            host = ssdpDevice.host,
+                            port = 8060 // ECP always on 8060
+                        )
+                        addDiscoveredDevice(rokuDevice)
+                        // Try to get friendly name
+                        fetchRokuDeviceName(rokuDevice)
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "Roku discovery error", e)
+                }
+            }
+
+            // Discover Kodi devices via SSDP
+            // Note: The UPnP MediaRenderer search target is generic — many non-Kodi devices
+            // respond to it (smart TVs, DLNA speakers, etc.). We verify each candidate by
+            // pinging Kodi's JSON-RPC endpoint before adding it to the list.
+            launch(Dispatchers.IO) {
+                try {
+                    ssdpDiscovery.discover(KODI_SEARCH_TARGET, timeoutMs = 5000).collect { ssdpDevice ->
+                        val verified = verifyKodiDevice(ssdpDevice.host, 8080)
+                        if (verified) {
+                            val kodiDevice = CastDevice(
+                                id = "kodi_${ssdpDevice.host}",
+                                name = ssdpDevice.friendlyName ?: "Kodi (${ssdpDevice.host})",
+                                protocol = CastProtocol.KODI,
+                                host = ssdpDevice.host,
+                                port = 8080
+                            )
+                            addDiscoveredDevice(kodiDevice)
+                        }
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "Kodi discovery error", e)
+                }
+            }
+
+            // Discover AirPlay devices via mDNS
+            launch(Dispatchers.IO) {
+                try {
+                    val mdnsDiscovery = MdnsDiscovery(context)
+                    mdnsDiscovery.discover(AIRPLAY_SERVICE_TYPE).collect { mdnsDevice ->
+                        val airPlayDevice = CastDevice(
+                            id = "airplay_${mdnsDevice.host}",
+                            name = mdnsDevice.name,
+                            protocol = CastProtocol.AIRPLAY,
+                            host = mdnsDevice.host,
+                            port = mdnsDevice.port
+                        )
+                        addDiscoveredDevice(airPlayDevice)
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "AirPlay discovery error", e)
+                }
+            }
+        }
+    }
+
+    /**
+     * Stop all device discovery.
+     */
+    fun stopDiscovery() {
+        discoveryJob?.cancel()
+        discoveryJob = null
+        chromecastTarget.stopDiscovery()
+        releaseMulticastLock()
+    }
+
+    /**
+     * Connect to a discovered device.
+     */
+    suspend fun connectToDevice(device: CastDevice) {
+        // Disconnect from current target if different protocol
+        if (activeTarget != null && _activeProtocol.value != device.protocol) {
+            disconnect()
+        }
+
+        val target = when (device.protocol) {
+            CastProtocol.CHROMECAST -> {
+                // For Chromecast, use route selection (connection happens async via Cast SDK)
+                val route = device.extras as? MediaRouter.RouteInfo
+                if (route != null) {
+                    // The actual connection will be handled by CastHelper's session listener
+                    // which triggers the init block's observer above
+                    return
+                }
+                return
+            }
+            CastProtocol.ROKU -> rokuTarget
+            CastProtocol.KODI -> kodiTarget
+            CastProtocol.AIRPLAY -> airPlayTarget
+        }
+
+        target.connect(device)
+        activeTarget = target
+        _activeProtocol.value = device.protocol
+        observeActiveTargetState()
+    }
+
+    /**
+     * Disconnect from the current casting device.
+     */
+    suspend fun disconnect() {
+        activeTarget?.disconnect()
+        activeTarget = null
+        _activeProtocol.value = null
+        _isConnected.value = false
+        _isPlaying.value = false
+        _currentPosition.value = 0L
+        _connectedDeviceName.value = null
+        stateObserverJob?.cancel()
+    }
+
+    /**
+     * Cast an audiobook to the active device.
+     */
+    suspend fun castAudiobook(
+        audiobook: Audiobook,
+        streamUrl: String,
+        coverUrl: String?,
+        positionSeconds: Long
+    ) {
+        val target = activeTarget ?: return
+        val protocol = _activeProtocol.value ?: return
+
+        // For Chromecast, use the existing CastHelper flow which handles auth tokens
+        if (protocol == CastProtocol.CHROMECAST) {
+            chromecastTarget.castAudiobook(audiobook, streamUrl, coverUrl, positionSeconds)
+            return
+        }
+
+        // For other protocols, append auth token to URL
+        val token = authRepository.getTokenSync()
+        val authenticatedUrl = if (token != null) "$streamUrl?token=$token" else streamUrl
+        val authenticatedCoverUrl = if (coverUrl != null && token != null) {
+            "$coverUrl?token=$token"
+        } else {
+            coverUrl
+        }
+
+        target.loadMedia(
+            streamUrl = authenticatedUrl,
+            title = audiobook.title,
+            author = audiobook.author,
+            coverUrl = authenticatedCoverUrl,
+            positionSeconds = positionSeconds
+        )
+    }
+
+    suspend fun play() {
+        activeTarget?.play()
+    }
+
+    suspend fun pause() {
+        activeTarget?.pause()
+    }
+
+    suspend fun seek(positionSeconds: Long) {
+        activeTarget?.seek(positionSeconds)
+    }
+
+    suspend fun stop() {
+        activeTarget?.stop()
+    }
+
+    fun isCasting(): Boolean {
+        return activeTarget != null && _isConnected.value
+    }
+
+    fun getCurrentPosition(): Long {
+        return _currentPosition.value
+    }
+
+    /**
+     * Get the Chromecast target for direct route selection in the UI.
+     * This is needed because Chromecast connection is initiated by selecting a MediaRouter route,
+     * not through the generic connect() path.
+     */
+    fun getChromecastTarget(): ChromecastTarget = chromecastTarget
+
+    // -- Private helpers --
+
+    @Synchronized
+    private fun updateDeviceList(protocol: CastProtocol, devices: List<CastDevice>) {
+        val current = _discoveredDevices.value.toMutableList()
+        current.removeAll { it.protocol == protocol }
+        current.addAll(devices)
+        _discoveredDevices.value = current
+    }
+
+    @Synchronized
+    private fun addDiscoveredDevice(device: CastDevice) {
+        val current = _discoveredDevices.value.toMutableList()
+        // Replace if same ID, add if new
+        val index = current.indexOfFirst { it.id == device.id }
+        if (index >= 0) {
+            current[index] = device
+        } else {
+            current.add(device)
+        }
+        _discoveredDevices.value = current
+    }
+
+    private fun observeActiveTargetState() {
+        stateObserverJob?.cancel()
+        val target = activeTarget ?: return
+
+        stateObserverJob = scope.launch {
+            launch { target.isConnected.collect { _isConnected.value = it } }
+            launch { target.isPlaying.collect { _isPlaying.value = it } }
+            launch { target.currentPosition.collect { _currentPosition.value = it } }
+            launch { target.connectedDeviceName.collect { _connectedDeviceName.value = it } }
+        }
+    }
+
+    /**
+     * Verify that a discovered UPnP MediaRenderer is actually running Kodi
+     * by pinging its JSON-RPC endpoint. Many non-Kodi devices (Samsung TVs,
+     * DLNA speakers, etc.) respond to the generic MediaRenderer SSDP search.
+     */
+    private fun verifyKodiDevice(host: String, port: Int): Boolean {
+        return try {
+            val payload = org.json.JSONObject().apply {
+                put("jsonrpc", "2.0")
+                put("method", "JSONRPC.Ping")
+                put("params", org.json.JSONObject())
+                put("id", 1)
+            }
+            val request = okhttp3.Request.Builder()
+                .url("http://$host:$port/jsonrpc")
+                .post(
+                    okhttp3.RequestBody.create(
+                        "application/json".toMediaType(),
+                        payload.toString()
+                    )
+                )
+                .build()
+            val response = localHttpClient.newCall(request).execute()
+            val body = response.body?.string() ?: ""
+            response.close()
+            // Kodi responds with {"id":1,"jsonrpc":"2.0","result":"pong"}
+            val isKodi = body.contains("pong")
+            Log.d(TAG, "Kodi verification for $host:$port = $isKodi")
+            isKodi
+        } catch (e: Exception) {
+            Log.v(TAG, "Not a Kodi device at $host:$port: ${e.message}")
+            false
+        }
+    }
+
+    private fun fetchRokuDeviceName(device: CastDevice) {
+        scope.launch(Dispatchers.IO) {
+            try {
+                val request = okhttp3.Request.Builder()
+                    .url("http://${device.host}:${device.port}/query/device-info")
+                    .get()
+                    .build()
+                val response = localHttpClient.newCall(request).execute()
+                val body = response.body?.string() ?: ""
+                response.close()
+
+                val nameMatch = Regex("<friendly-device-name>(.*?)</friendly-device-name>").find(body)
+                val friendlyName = nameMatch?.groupValues?.get(1)
+                if (friendlyName != null) {
+                    val updatedDevice = device.copy(name = friendlyName)
+                    addDiscoveredDevice(updatedDevice)
+                }
+            } catch (e: Exception) {
+                Log.v(TAG, "Could not fetch Roku device name: ${e.message}")
+            }
+        }
+    }
+
+    private fun acquireMulticastLock(context: Context) {
+        try {
+            val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            multicastLock = wifiManager.createMulticastLock("sappho_cast_discovery").apply {
+                setReferenceCounted(true)
+                acquire()
+            }
+            Log.d(TAG, "Multicast lock acquired")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to acquire multicast lock", e)
+        }
+    }
+
+    private fun releaseMulticastLock() {
+        try {
+            multicastLock?.let {
+                if (it.isHeld) {
+                    it.release()
+                    Log.d(TAG, "Multicast lock released")
+                }
+            }
+            multicastLock = null
+        } catch (e: Exception) {
+            Log.e(TAG, "Error releasing multicast lock", e)
+        }
+    }
+}

--- a/app/src/main/java/com/sappho/audiobooks/cast/CastTarget.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/CastTarget.kt
@@ -1,0 +1,45 @@
+package com.sappho.audiobooks.cast
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Protocol-agnostic interface for casting audio to external devices.
+ * Each casting protocol (Chromecast, Roku, Kodi, AirPlay) implements this interface.
+ */
+interface CastTarget {
+    val protocol: CastProtocol
+    val isConnected: StateFlow<Boolean>
+    val isPlaying: StateFlow<Boolean>
+    val currentPosition: StateFlow<Long>  // seconds
+    val connectedDeviceName: StateFlow<String?>
+
+    suspend fun connect(device: CastDevice)
+    suspend fun disconnect()
+    suspend fun loadMedia(
+        streamUrl: String,
+        title: String,
+        author: String?,
+        coverUrl: String?,
+        positionSeconds: Long
+    )
+    suspend fun play()
+    suspend fun pause()
+    suspend fun seek(positionSeconds: Long)
+    suspend fun stop()
+}
+
+enum class CastProtocol {
+    CHROMECAST,
+    ROKU,
+    KODI,
+    AIRPLAY
+}
+
+data class CastDevice(
+    val id: String,
+    val name: String,
+    val protocol: CastProtocol,
+    val host: String,
+    val port: Int,
+    val extras: Any? = null  // Protocol-specific data (e.g., MediaRouter.RouteInfo for Chromecast)
+)

--- a/app/src/main/java/com/sappho/audiobooks/cast/discovery/MdnsDiscovery.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/discovery/MdnsDiscovery.kt
@@ -1,0 +1,101 @@
+package com.sappho.audiobooks.cast.discovery
+
+import android.content.Context
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import android.util.Log
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+data class MdnsDevice(
+    val name: String,
+    val host: String,
+    val port: Int,
+    val type: String
+)
+
+/**
+ * mDNS/Bonjour discovery using Android's NsdManager.
+ * Used for AirPlay device discovery (_airplay._tcp).
+ */
+class MdnsDiscovery(private val context: Context) {
+
+    companion object {
+        private const val TAG = "MdnsDiscovery"
+    }
+
+    /**
+     * Discover mDNS services of the given type.
+     *
+     * @param serviceType The mDNS service type (e.g., "_airplay._tcp.")
+     */
+    fun discover(serviceType: String): Flow<MdnsDevice> = callbackFlow {
+        val nsdManager = context.getSystemService(Context.NSD_SERVICE) as NsdManager
+
+        val resolveListener = object : NsdManager.ResolveListener {
+            override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+                Log.e(TAG, "Resolve failed for ${serviceInfo.serviceName}: errorCode=$errorCode")
+            }
+
+            override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
+                val host = serviceInfo.host?.hostAddress ?: return
+                val device = MdnsDevice(
+                    name = serviceInfo.serviceName,
+                    host = host,
+                    port = serviceInfo.port,
+                    type = serviceType
+                )
+                Log.d(TAG, "Resolved: ${device.name} at ${device.host}:${device.port}")
+                trySend(device)
+            }
+        }
+
+        val discoveryListener = object : NsdManager.DiscoveryListener {
+            override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
+                Log.e(TAG, "Start discovery failed: errorCode=$errorCode")
+                close()
+            }
+
+            override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
+                Log.e(TAG, "Stop discovery failed: errorCode=$errorCode")
+            }
+
+            override fun onDiscoveryStarted(serviceType: String) {
+                Log.d(TAG, "Discovery started for $serviceType")
+            }
+
+            override fun onDiscoveryStopped(serviceType: String) {
+                Log.d(TAG, "Discovery stopped for $serviceType")
+            }
+
+            override fun onServiceFound(serviceInfo: NsdServiceInfo) {
+                Log.d(TAG, "Service found: ${serviceInfo.serviceName}")
+                try {
+                    nsdManager.resolveService(serviceInfo, resolveListener)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error resolving service", e)
+                }
+            }
+
+            override fun onServiceLost(serviceInfo: NsdServiceInfo) {
+                Log.d(TAG, "Service lost: ${serviceInfo.serviceName}")
+            }
+        }
+
+        try {
+            nsdManager.discoverServices(serviceType, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start mDNS discovery", e)
+            close(e)
+        }
+
+        awaitClose {
+            try {
+                nsdManager.stopServiceDiscovery(discoveryListener)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error stopping mDNS discovery", e)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sappho/audiobooks/cast/discovery/SsdpDiscovery.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/discovery/SsdpDiscovery.kt
@@ -1,0 +1,131 @@
+package com.sappho.audiobooks.cast.discovery
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import java.net.SocketTimeoutException
+
+data class SsdpDevice(
+    val location: String,   // URL from LOCATION header
+    val usn: String,        // Unique Service Name
+    val host: String,       // Extracted IP
+    val port: Int,          // Extracted port
+    val server: String?,    // SERVER header value
+    val friendlyName: String? = null
+)
+
+/**
+ * SSDP (Simple Service Discovery Protocol) discovery for finding devices
+ * on the local network. Used by Roku (roku:ecp) and Kodi (UPnP MediaRenderer).
+ */
+class SsdpDiscovery {
+
+    companion object {
+        private const val TAG = "SsdpDiscovery"
+        private const val SSDP_ADDRESS = "239.255.255.250"
+        private const val SSDP_PORT = 1900
+        private const val BUFFER_SIZE = 4096
+    }
+
+    /**
+     * Send M-SEARCH multicast and collect responses as a Flow.
+     *
+     * @param searchTarget The SSDP search target (e.g., "roku:ecp" or "urn:schemas-upnp-org:device:MediaRenderer:1")
+     * @param timeoutMs How long to listen for responses
+     */
+    fun discover(searchTarget: String, timeoutMs: Long = 3000): Flow<SsdpDevice> = flow {
+        var socket: DatagramSocket? = null
+        try {
+            socket = DatagramSocket().apply {
+                soTimeout = timeoutMs.toInt()
+                broadcast = true
+            }
+
+            val searchMessage = buildMSearchMessage(searchTarget)
+            val address = InetAddress.getByName(SSDP_ADDRESS)
+            val packet = DatagramPacket(
+                searchMessage.toByteArray(),
+                searchMessage.length,
+                address,
+                SSDP_PORT
+            )
+
+            // Send M-SEARCH
+            socket.send(packet)
+            Log.d(TAG, "Sent M-SEARCH for '$searchTarget'")
+
+            // Collect responses until timeout
+            val seen = mutableSetOf<String>()
+            val buffer = ByteArray(BUFFER_SIZE)
+            val responsePacket = DatagramPacket(buffer, buffer.size)
+
+            while (true) {
+                try {
+                    socket.receive(responsePacket)
+                    val response = String(responsePacket.data, 0, responsePacket.length)
+                    val device = parseResponse(response)
+                    if (device != null && seen.add(device.usn)) {
+                        Log.d(TAG, "Discovered: ${device.host}:${device.port} (${device.server})")
+                        emit(device)
+                    }
+                } catch (_: SocketTimeoutException) {
+                    break
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "SSDP discovery error", e)
+        } finally {
+            socket?.close()
+        }
+    }.flowOn(Dispatchers.IO)
+
+    private fun buildMSearchMessage(searchTarget: String): String {
+        return "M-SEARCH * HTTP/1.1\r\n" +
+                "HOST: $SSDP_ADDRESS:$SSDP_PORT\r\n" +
+                "MAN: \"ssdp:discover\"\r\n" +
+                "MX: 3\r\n" +
+                "ST: $searchTarget\r\n" +
+                "\r\n"
+    }
+
+    private fun parseResponse(response: String): SsdpDevice? {
+        val headers = mutableMapOf<String, String>()
+        response.lines().forEach { line ->
+            val colonIndex = line.indexOf(':')
+            if (colonIndex > 0) {
+                val key = line.substring(0, colonIndex).trim().uppercase()
+                val value = line.substring(colonIndex + 1).trim()
+                headers[key] = value
+            }
+        }
+
+        val location = headers["LOCATION"] ?: return null
+        val usn = headers["USN"] ?: location
+
+        // Extract host and port from LOCATION URL
+        val hostPort = extractHostPort(location) ?: return null
+
+        return SsdpDevice(
+            location = location,
+            usn = usn,
+            host = hostPort.first,
+            port = hostPort.second,
+            server = headers["SERVER"]
+        )
+    }
+
+    private fun extractHostPort(url: String): Pair<String, Int>? {
+        return try {
+            val java_url = java.net.URL(url)
+            val port = if (java_url.port == -1) java_url.defaultPort else java_url.port
+            Pair(java_url.host, port)
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/sappho/audiobooks/cast/targets/AirPlayCastTarget.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/targets/AirPlayCastTarget.kt
@@ -1,0 +1,220 @@
+package com.sappho.audiobooks.cast.targets
+
+import android.util.Log
+import com.sappho.audiobooks.cast.CastDevice
+import com.sappho.audiobooks.cast.CastProtocol
+import com.sappho.audiobooks.cast.CastTarget
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+/**
+ * AirPlay 1 casting via HTTP protocol on port 7000.
+ * Marked as experimental — AirPlay 2 devices with encryption may not work.
+ *
+ * Protocol reference: https://nto.github.io/AirPlay.html
+ */
+class AirPlayCastTarget(
+    private val httpClient: OkHttpClient
+) : CastTarget {
+
+    companion object {
+        private const val TAG = "AirPlayCastTarget"
+        private const val POLL_INTERVAL_MS = 1000L
+    }
+
+    override val protocol = CastProtocol.AIRPLAY
+
+    private val _isConnected = MutableStateFlow(false)
+    override val isConnected: StateFlow<Boolean> = _isConnected
+
+    private val _isPlaying = MutableStateFlow(false)
+    override val isPlaying: StateFlow<Boolean> = _isPlaying
+
+    private val _currentPosition = MutableStateFlow(0L)
+    override val currentPosition: StateFlow<Long> = _currentPosition
+
+    private val _connectedDeviceName = MutableStateFlow<String?>(null)
+    override val connectedDeviceName: StateFlow<String?> = _connectedDeviceName
+
+    private var connectedDevice: CastDevice? = null
+    private var pollingJob: Job? = null
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private var mediaDuration: Long = 0L
+
+    override suspend fun connect(device: CastDevice) {
+        connectedDevice = device
+        _connectedDeviceName.value = device.name
+        _isConnected.value = true
+        startPolling()
+        Log.d(TAG, "Connected to AirPlay: ${device.name} (${device.host}:${device.port})")
+    }
+
+    override suspend fun disconnect() {
+        val device = connectedDevice
+        if (device != null) {
+            try {
+                val request = Request.Builder()
+                    .url("http://${device.host}:${device.port}/stop")
+                    .post("".toRequestBody("text/plain".toMediaType()))
+                    .build()
+                httpClient.newCall(request).execute().close()
+            } catch (e: Exception) {
+                Log.e(TAG, "Error sending stop on disconnect", e)
+            }
+        }
+        stopPolling()
+        connectedDevice = null
+        _isConnected.value = false
+        _connectedDeviceName.value = null
+        _isPlaying.value = false
+        _currentPosition.value = 0L
+        mediaDuration = 0L
+        Log.d(TAG, "Disconnected from AirPlay")
+    }
+
+    override suspend fun loadMedia(
+        streamUrl: String,
+        title: String,
+        author: String?,
+        coverUrl: String?,
+        positionSeconds: Long
+    ) {
+        val device = connectedDevice ?: return
+        val baseUrl = "http://${device.host}:${device.port}"
+
+        try {
+            // AirPlay 1 /play endpoint expects a text/parameters body
+            val startPosition = if (mediaDuration > 0) {
+                positionSeconds.toFloat() / mediaDuration.toFloat()
+            } else {
+                0f
+            }
+
+            val body = "Content-Location: $streamUrl\nStart-Position: $startPosition\n"
+
+            val request = Request.Builder()
+                .url("$baseUrl/play")
+                .post(body.toRequestBody("text/parameters".toMediaType()))
+                .build()
+
+            val response = httpClient.newCall(request).execute()
+            Log.d(TAG, "AirPlay /play: ${response.code}")
+            response.close()
+
+            _isPlaying.value = true
+            _currentPosition.value = positionSeconds
+        } catch (e: Exception) {
+            Log.e(TAG, "Error loading media on AirPlay", e)
+        }
+    }
+
+    override suspend fun play() {
+        val device = connectedDevice ?: return
+        try {
+            val request = Request.Builder()
+                .url("http://${device.host}:${device.port}/rate?value=1.0")
+                .post("".toRequestBody("text/plain".toMediaType()))
+                .build()
+            httpClient.newCall(request).execute().close()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error sending play", e)
+        }
+    }
+
+    override suspend fun pause() {
+        val device = connectedDevice ?: return
+        try {
+            val request = Request.Builder()
+                .url("http://${device.host}:${device.port}/rate?value=0.0")
+                .post("".toRequestBody("text/plain".toMediaType()))
+                .build()
+            httpClient.newCall(request).execute().close()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error sending pause", e)
+        }
+    }
+
+    override suspend fun seek(positionSeconds: Long) {
+        val device = connectedDevice ?: return
+        try {
+            val request = Request.Builder()
+                .url("http://${device.host}:${device.port}/scrub?position=$positionSeconds")
+                .post("".toRequestBody("text/plain".toMediaType()))
+                .build()
+            httpClient.newCall(request).execute().close()
+            _currentPosition.value = positionSeconds
+        } catch (e: Exception) {
+            Log.e(TAG, "Error seeking on AirPlay", e)
+        }
+    }
+
+    override suspend fun stop() {
+        val device = connectedDevice ?: return
+        try {
+            val request = Request.Builder()
+                .url("http://${device.host}:${device.port}/stop")
+                .post("".toRequestBody("text/plain".toMediaType()))
+                .build()
+            httpClient.newCall(request).execute().close()
+            _isPlaying.value = false
+        } catch (e: Exception) {
+            Log.e(TAG, "Error stopping AirPlay", e)
+        }
+    }
+
+    private fun startPolling() {
+        pollingJob?.cancel()
+        pollingJob = scope.launch {
+            while (isActive) {
+                pollPlaybackInfo()
+                delay(POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun stopPolling() {
+        pollingJob?.cancel()
+        pollingJob = null
+    }
+
+    private fun pollPlaybackInfo() {
+        val device = connectedDevice ?: return
+        try {
+            val request = Request.Builder()
+                .url("http://${device.host}:${device.port}/scrub")
+                .get()
+                .build()
+            val response = httpClient.newCall(request).execute()
+            val body = response.body?.string() ?: ""
+            response.close()
+
+            // Parse response: "duration: 12345.67\nposition: 89.01\n"
+            val durationMatch = Regex("duration:\\s*([\\d.]+)").find(body)
+            val positionMatch = Regex("position:\\s*([\\d.]+)").find(body)
+
+            val duration = durationMatch?.groupValues?.get(1)?.toDoubleOrNull()
+            val position = positionMatch?.groupValues?.get(1)?.toDoubleOrNull()
+
+            if (duration != null) {
+                mediaDuration = duration.toLong()
+            }
+            if (position != null) {
+                _currentPosition.value = position.toLong()
+                _isPlaying.value = true
+            }
+        } catch (e: Exception) {
+            // Expected when no media is playing
+            Log.v(TAG, "Polling error: ${e.message}")
+        }
+    }
+}

--- a/app/src/main/java/com/sappho/audiobooks/cast/targets/ChromecastTarget.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/targets/ChromecastTarget.kt
@@ -1,0 +1,98 @@
+package com.sappho.audiobooks.cast.targets
+
+import android.content.Context
+import androidx.mediarouter.media.MediaRouter
+import com.sappho.audiobooks.cast.CastDevice
+import com.sappho.audiobooks.cast.CastHelper
+import com.sappho.audiobooks.cast.CastProtocol
+import com.sappho.audiobooks.cast.CastTarget
+import com.sappho.audiobooks.domain.model.Audiobook
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Chromecast implementation that wraps the existing CastHelper.
+ * This is a thin adapter - all actual Chromecast logic remains in CastHelper.
+ */
+class ChromecastTarget(
+    private val castHelper: CastHelper
+) : CastTarget {
+
+    override val protocol = CastProtocol.CHROMECAST
+    override val isConnected: StateFlow<Boolean> = castHelper.isConnected
+    override val isPlaying: StateFlow<Boolean> = castHelper.isPlayingFlow
+    override val currentPosition: StateFlow<Long> = castHelper.currentPositionFlow
+    override val connectedDeviceName: StateFlow<String?> = castHelper.connectedDeviceName
+
+    override suspend fun connect(device: CastDevice) {
+        // Chromecast connection is handled by selecting a MediaRouter route
+        // The route is stored in device.extras
+        val route = device.extras as? MediaRouter.RouteInfo
+        if (route != null) {
+            castHelper.selectRoute(device.extras as? Context ?: return, route)
+        }
+    }
+
+    override suspend fun disconnect() {
+        castHelper.disconnectCast()
+    }
+
+    override suspend fun loadMedia(
+        streamUrl: String,
+        title: String,
+        author: String?,
+        coverUrl: String?,
+        positionSeconds: Long
+    ) {
+        // CastHelper.castAudiobook handles auth token appending and pending media logic.
+        // We create a minimal Audiobook for compatibility with the existing API.
+        // Note: The actual castAudiobook call is made from CastManager which has access
+        // to the full Audiobook object.
+    }
+
+    override suspend fun play() {
+        castHelper.play()
+    }
+
+    override suspend fun pause() {
+        castHelper.pause()
+    }
+
+    override suspend fun seek(positionSeconds: Long) {
+        castHelper.seek(positionSeconds)
+    }
+
+    override suspend fun stop() {
+        castHelper.stopCasting()
+    }
+
+    // -- Chromecast-specific helpers used by CastManager --
+
+    fun startDiscovery(context: Context) {
+        castHelper.startDiscovery(context)
+    }
+
+    fun stopDiscovery() {
+        castHelper.stopDiscovery()
+    }
+
+    fun getAvailableRoutes(): StateFlow<List<MediaRouter.RouteInfo>> {
+        return castHelper.availableRoutes
+    }
+
+    fun selectRoute(context: Context, route: MediaRouter.RouteInfo) {
+        castHelper.selectRoute(context, route)
+    }
+
+    fun castAudiobook(
+        audiobook: Audiobook,
+        streamUrl: String,
+        coverUrl: String?,
+        currentPosition: Long
+    ) {
+        castHelper.castAudiobook(audiobook, streamUrl, coverUrl, currentPosition)
+    }
+
+    fun isCasting(): Boolean = castHelper.isCasting()
+
+    fun getCurrentPositionMs(): Long = castHelper.getCurrentPosition()
+}

--- a/app/src/main/java/com/sappho/audiobooks/cast/targets/KodiCastTarget.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/targets/KodiCastTarget.kt
@@ -1,0 +1,276 @@
+package com.sappho.audiobooks.cast.targets
+
+import android.util.Log
+import com.sappho.audiobooks.cast.CastDevice
+import com.sappho.audiobooks.cast.CastProtocol
+import com.sappho.audiobooks.cast.CastTarget
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+/**
+ * Kodi/Fire TV casting via JSON-RPC over HTTP.
+ * Default Kodi web server port is 8080.
+ *
+ * JSON-RPC reference: https://kodi.wiki/view/JSON-RPC_API
+ */
+class KodiCastTarget(
+    private val httpClient: OkHttpClient
+) : CastTarget {
+
+    companion object {
+        private const val TAG = "KodiCastTarget"
+        private const val POLL_INTERVAL_MS = 1000L
+    }
+
+    override val protocol = CastProtocol.KODI
+
+    private val _isConnected = MutableStateFlow(false)
+    override val isConnected: StateFlow<Boolean> = _isConnected
+
+    private val _isPlaying = MutableStateFlow(false)
+    override val isPlaying: StateFlow<Boolean> = _isPlaying
+
+    private val _currentPosition = MutableStateFlow(0L)
+    override val currentPosition: StateFlow<Long> = _currentPosition
+
+    private val _connectedDeviceName = MutableStateFlow<String?>(null)
+    override val connectedDeviceName: StateFlow<String?> = _connectedDeviceName
+
+    private var connectedDevice: CastDevice? = null
+    private var pollingJob: Job? = null
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private var activePlayerId: Int? = null
+
+    override suspend fun connect(device: CastDevice) {
+        // Verify connectivity by pinging Kodi's JSON-RPC
+        val baseUrl = "http://${device.host}:${device.port}"
+        try {
+            val result = sendJsonRpc(baseUrl, "JSONRPC.Ping", JSONObject())
+            if (result != null) {
+                connectedDevice = device
+                _connectedDeviceName.value = device.name
+                _isConnected.value = true
+                startPolling()
+                Log.d(TAG, "Connected to Kodi: ${device.name} (${device.host}:${device.port})")
+            } else {
+                Log.e(TAG, "Failed to ping Kodi at $baseUrl")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error connecting to Kodi", e)
+        }
+    }
+
+    override suspend fun disconnect() {
+        stopPolling()
+        connectedDevice = null
+        activePlayerId = null
+        _isConnected.value = false
+        _connectedDeviceName.value = null
+        _isPlaying.value = false
+        _currentPosition.value = 0L
+        Log.d(TAG, "Disconnected from Kodi")
+    }
+
+    override suspend fun loadMedia(
+        streamUrl: String,
+        title: String,
+        author: String?,
+        coverUrl: String?,
+        positionSeconds: Long
+    ) {
+        val device = connectedDevice ?: return
+        val baseUrl = "http://${device.host}:${device.port}"
+
+        try {
+            // Use Player.Open to start playback
+            val params = JSONObject().apply {
+                put("item", JSONObject().apply {
+                    put("file", streamUrl)
+                })
+            }
+
+            val result = sendJsonRpc(baseUrl, "Player.Open", params)
+            Log.d(TAG, "Player.Open result: $result")
+
+            // Wait briefly for player to initialize
+            delay(1000)
+
+            // Find the active player ID
+            activePlayerId = getActivePlayerId(baseUrl)
+
+            // Seek to position if needed
+            if (positionSeconds > 0 && activePlayerId != null) {
+                seek(positionSeconds)
+            }
+
+            _isPlaying.value = true
+            _currentPosition.value = positionSeconds
+        } catch (e: Exception) {
+            Log.e(TAG, "Error loading media on Kodi", e)
+        }
+    }
+
+    override suspend fun play() {
+        val device = connectedDevice ?: return
+        val baseUrl = "http://${device.host}:${device.port}"
+        val playerId = activePlayerId ?: getActivePlayerId(baseUrl) ?: return
+
+        try {
+            val params = JSONObject().apply {
+                put("playerid", playerId)
+            }
+            sendJsonRpc(baseUrl, "Player.PlayPause", params)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error toggling play/pause on Kodi", e)
+        }
+    }
+
+    override suspend fun pause() {
+        play() // PlayPause is a toggle
+    }
+
+    override suspend fun seek(positionSeconds: Long) {
+        val device = connectedDevice ?: return
+        val baseUrl = "http://${device.host}:${device.port}"
+        val playerId = activePlayerId ?: getActivePlayerId(baseUrl) ?: return
+
+        try {
+            val hours = (positionSeconds / 3600).toInt()
+            val minutes = ((positionSeconds % 3600) / 60).toInt()
+            val seconds = (positionSeconds % 60).toInt()
+
+            val params = JSONObject().apply {
+                put("playerid", playerId)
+                put("value", JSONObject().apply {
+                    put("time", JSONObject().apply {
+                        put("hours", hours)
+                        put("minutes", minutes)
+                        put("seconds", seconds)
+                        put("milliseconds", 0)
+                    })
+                })
+            }
+            sendJsonRpc(baseUrl, "Player.Seek", params)
+            _currentPosition.value = positionSeconds
+        } catch (e: Exception) {
+            Log.e(TAG, "Error seeking on Kodi", e)
+        }
+    }
+
+    override suspend fun stop() {
+        val device = connectedDevice ?: return
+        val baseUrl = "http://${device.host}:${device.port}"
+        val playerId = activePlayerId ?: getActivePlayerId(baseUrl) ?: return
+
+        try {
+            val params = JSONObject().apply {
+                put("playerid", playerId)
+            }
+            sendJsonRpc(baseUrl, "Player.Stop", params)
+            _isPlaying.value = false
+            activePlayerId = null
+        } catch (e: Exception) {
+            Log.e(TAG, "Error stopping Kodi playback", e)
+        }
+    }
+
+    private fun sendJsonRpc(baseUrl: String, method: String, params: JSONObject): JSONObject? {
+        val payload = JSONObject().apply {
+            put("jsonrpc", "2.0")
+            put("method", method)
+            put("params", params)
+            put("id", 1)
+        }
+
+        val request = Request.Builder()
+            .url("$baseUrl/jsonrpc")
+            .post(payload.toString().toRequestBody("application/json".toMediaType()))
+            .build()
+
+        return try {
+            val response = httpClient.newCall(request).execute()
+            val body = response.body?.string()
+            response.close()
+            body?.let { JSONObject(it) }
+        } catch (e: Exception) {
+            Log.e(TAG, "JSON-RPC error for $method", e)
+            null
+        }
+    }
+
+    private fun getActivePlayerId(baseUrl: String): Int? {
+        val result = sendJsonRpc(baseUrl, "Player.GetActivePlayers", JSONObject())
+        val players = result?.optJSONArray("result")
+        if (players != null && players.length() > 0) {
+            return players.getJSONObject(0).optInt("playerid", -1).takeIf { it >= 0 }
+        }
+        return null
+    }
+
+    private fun startPolling() {
+        pollingJob?.cancel()
+        pollingJob = scope.launch {
+            while (isActive) {
+                pollPlayerStatus()
+                delay(POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun stopPolling() {
+        pollingJob?.cancel()
+        pollingJob = null
+    }
+
+    private fun pollPlayerStatus() {
+        val device = connectedDevice ?: return
+        val baseUrl = "http://${device.host}:${device.port}"
+
+        try {
+            // Get active player
+            val playerId = getActivePlayerId(baseUrl)
+            if (playerId == null) {
+                _isPlaying.value = false
+                activePlayerId = null
+                return
+            }
+            activePlayerId = playerId
+
+            // Get player properties
+            val params = JSONObject().apply {
+                put("playerid", playerId)
+                put("properties", org.json.JSONArray().apply {
+                    put("time")
+                    put("speed")
+                })
+            }
+            val result = sendJsonRpc(baseUrl, "Player.GetProperties", params)
+            val props = result?.optJSONObject("result")
+            if (props != null) {
+                val speed = props.optInt("speed", 0)
+                _isPlaying.value = speed > 0
+
+                val time = props.optJSONObject("time")
+                if (time != null) {
+                    val hours = time.optLong("hours", 0)
+                    val minutes = time.optLong("minutes", 0)
+                    val seconds = time.optLong("seconds", 0)
+                    _currentPosition.value = hours * 3600 + minutes * 60 + seconds
+                }
+            }
+        } catch (e: Exception) {
+            Log.v(TAG, "Polling error: ${e.message}")
+        }
+    }
+}

--- a/app/src/main/java/com/sappho/audiobooks/cast/targets/RokuCastTarget.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/targets/RokuCastTarget.kt
@@ -1,0 +1,196 @@
+package com.sappho.audiobooks.cast.targets
+
+import android.util.Log
+import com.sappho.audiobooks.cast.CastDevice
+import com.sappho.audiobooks.cast.CastProtocol
+import com.sappho.audiobooks.cast.CastTarget
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.net.URLEncoder
+
+/**
+ * Roku casting via External Control Protocol (ECP).
+ * Uses PlayOnRoku app (app ID 15985) for audio playback on Roku OS 11.5+.
+ *
+ * ECP reference: https://developer.roku.com/docs/developer-program/dev-tools/external-control-api.md
+ */
+class RokuCastTarget(
+    private val httpClient: OkHttpClient
+) : CastTarget {
+
+    companion object {
+        private const val TAG = "RokuCastTarget"
+        private const val PLAY_ON_ROKU_APP_ID = "15985"
+        private const val POLL_INTERVAL_MS = 1000L
+    }
+
+    override val protocol = CastProtocol.ROKU
+
+    private val _isConnected = MutableStateFlow(false)
+    override val isConnected: StateFlow<Boolean> = _isConnected
+
+    private val _isPlaying = MutableStateFlow(false)
+    override val isPlaying: StateFlow<Boolean> = _isPlaying
+
+    private val _currentPosition = MutableStateFlow(0L)
+    override val currentPosition: StateFlow<Long> = _currentPosition
+
+    private val _connectedDeviceName = MutableStateFlow<String?>(null)
+    override val connectedDeviceName: StateFlow<String?> = _connectedDeviceName
+
+    private var connectedDevice: CastDevice? = null
+    private var pollingJob: Job? = null
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    override suspend fun connect(device: CastDevice) {
+        connectedDevice = device
+        _connectedDeviceName.value = device.name
+        _isConnected.value = true
+        startPolling()
+        Log.d(TAG, "Connected to Roku: ${device.name} (${device.host}:${device.port})")
+    }
+
+    override suspend fun disconnect() {
+        stopPolling()
+        connectedDevice = null
+        _isConnected.value = false
+        _connectedDeviceName.value = null
+        _isPlaying.value = false
+        _currentPosition.value = 0L
+        Log.d(TAG, "Disconnected from Roku")
+    }
+
+    override suspend fun loadMedia(
+        streamUrl: String,
+        title: String,
+        author: String?,
+        coverUrl: String?,
+        positionSeconds: Long
+    ) {
+        val device = connectedDevice ?: return
+        val baseUrl = "http://${device.host}:${device.port}"
+
+        try {
+            val encodedUrl = URLEncoder.encode(streamUrl, "UTF-8")
+            val encodedTitle = URLEncoder.encode(title, "UTF-8")
+            // Launch PlayOnRoku with the stream URL
+            val launchUrl = "$baseUrl/launch/$PLAY_ON_ROKU_APP_ID" +
+                    "?url=$encodedUrl" +
+                    "&mediaType=audio" +
+                    "&t=$positionSeconds" +
+                    "&songname=$encodedTitle"
+
+            val request = Request.Builder()
+                .url(launchUrl)
+                .post("".toRequestBody("text/plain".toMediaType()))
+                .build()
+
+            val response = httpClient.newCall(request).execute()
+            Log.d(TAG, "Launch PlayOnRoku: ${response.code}")
+            response.close()
+
+            _isPlaying.value = true
+            _currentPosition.value = positionSeconds
+        } catch (e: Exception) {
+            Log.e(TAG, "Error loading media on Roku", e)
+        }
+    }
+
+    override suspend fun play() {
+        sendKeypress("Play")
+    }
+
+    override suspend fun pause() {
+        sendKeypress("Play") // Play/Pause toggle on Roku
+    }
+
+    override suspend fun seek(positionSeconds: Long) {
+        // Roku ECP doesn't have direct seek — restart media at position
+        // This is a limitation of the PlayOnRoku app
+        Log.w(TAG, "Roku ECP does not support direct seek. Position: $positionSeconds")
+    }
+
+    override suspend fun stop() {
+        val device = connectedDevice ?: return
+        val baseUrl = "http://${device.host}:${device.port}"
+        try {
+            val request = Request.Builder()
+                .url("$baseUrl/keypress/Home")
+                .post("".toRequestBody("text/plain".toMediaType()))
+                .build()
+            httpClient.newCall(request).execute().close()
+            _isPlaying.value = false
+        } catch (e: Exception) {
+            Log.e(TAG, "Error stopping Roku playback", e)
+        }
+    }
+
+    private fun sendKeypress(key: String) {
+        val device = connectedDevice ?: return
+        val baseUrl = "http://${device.host}:${device.port}"
+        scope.launch {
+            try {
+                val request = Request.Builder()
+                    .url("$baseUrl/keypress/$key")
+                    .post("".toRequestBody("text/plain".toMediaType()))
+                    .build()
+                httpClient.newCall(request).execute().close()
+            } catch (e: Exception) {
+                Log.e(TAG, "Error sending keypress '$key'", e)
+            }
+        }
+    }
+
+    private fun startPolling() {
+        pollingJob?.cancel()
+        pollingJob = scope.launch {
+            while (isActive) {
+                pollMediaStatus()
+                delay(POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun stopPolling() {
+        pollingJob?.cancel()
+        pollingJob = null
+    }
+
+    private fun pollMediaStatus() {
+        val device = connectedDevice ?: return
+        val baseUrl = "http://${device.host}:${device.port}"
+        try {
+            val request = Request.Builder()
+                .url("$baseUrl/query/media-player")
+                .get()
+                .build()
+            val response = httpClient.newCall(request).execute()
+            val body = response.body?.string() ?: ""
+            response.close()
+
+            // Parse XML response for state and position
+            // Example: <player error="false" state="play"><position>12345 ms</position>...</player>
+            val stateMatch = Regex("state=\"(\\w+)\"").find(body)
+            val positionMatch = Regex("<position>(\\d+) ms</position>").find(body)
+
+            val state = stateMatch?.groupValues?.get(1)
+            val positionMs = positionMatch?.groupValues?.get(1)?.toLongOrNull() ?: 0L
+
+            _isPlaying.value = state == "play"
+            _currentPosition.value = positionMs / 1000
+        } catch (e: Exception) {
+            // Polling failure is expected when device goes offline
+            Log.v(TAG, "Polling error: ${e.message}")
+        }
+    }
+}

--- a/app/src/main/java/com/sappho/audiobooks/cast/ui/CastDialog.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/ui/CastDialog.kt
@@ -1,0 +1,546 @@
+package com.sappho.audiobooks.cast.ui
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Cast
+import androidx.compose.material.icons.filled.DesktopWindows
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Speaker
+import androidx.compose.material.icons.filled.Tv
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.sappho.audiobooks.cast.CastDevice
+import com.sappho.audiobooks.cast.CastManager
+import com.sappho.audiobooks.cast.CastProtocol
+import com.sappho.audiobooks.presentation.theme.LegacyBlueLight
+import com.sappho.audiobooks.presentation.theme.LegacyPurpleLight
+import com.sappho.audiobooks.presentation.theme.SapphoError
+import com.sappho.audiobooks.presentation.theme.SapphoIconDefault
+import com.sappho.audiobooks.presentation.theme.SapphoInfo
+import com.sappho.audiobooks.presentation.theme.SapphoSuccess
+import com.sappho.audiobooks.presentation.theme.SapphoSurface
+import com.sappho.audiobooks.presentation.theme.SapphoSurfaceLight
+import com.sappho.audiobooks.presentation.theme.SapphoWarning
+import com.sappho.audiobooks.presentation.theme.Timing
+
+/**
+ * Unified cast device picker dialog showing devices from all supported protocols.
+ * Extracted from PlayerActivity's inline cast dialog and extended for multi-protocol support.
+ */
+@Composable
+fun CastDialog(
+    castManager: CastManager,
+    onDeviceSelected: (CastDevice) -> Unit,
+    onDisconnect: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    val discoveredDevices by castManager.discoveredDevices.collectAsState()
+    val isCastConnected by castManager.isConnected.collectAsState()
+    val connectedDeviceName by castManager.connectedDeviceName.collectAsState()
+    val activeProtocol by castManager.activeProtocol.collectAsState()
+
+    var isScanning by remember { mutableStateOf(true) }
+
+    // Start/stop discovery with dialog lifecycle
+    DisposableEffect(Unit) {
+        castManager.startDiscovery(context)
+        onDispose {
+            castManager.stopDiscovery()
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        kotlinx.coroutines.delay(Timing.FEEDBACK_MEDIUM_MS)
+        isScanning = false
+    }
+
+    // Pulsing animation for scanning
+    val pulseTransition = rememberInfiniteTransition(label = "pulse")
+    val pulseScale by pulseTransition.animateFloat(
+        initialValue = 1f,
+        targetValue = 1.15f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(800, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "pulseScale"
+    )
+    val pulseAlpha by pulseTransition.animateFloat(
+        initialValue = 0.6f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(800, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "pulseAlpha"
+    )
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .background(
+                            Brush.linearGradient(
+                                colors = listOf(SapphoInfo, LegacyPurpleLight)
+                            )
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Cast,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+                Column {
+                    Text(
+                        "Cast Audio",
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 18.sp
+                    )
+                    Text(
+                        if (isCastConnected && connectedDeviceName != null)
+                            "Connected to $connectedDeviceName"
+                        else "Select a device",
+                        color = if (isCastConnected) SapphoSuccess else SapphoIconDefault,
+                        fontSize = 12.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                if (isCastConnected) {
+                    ConnectedState(
+                        deviceName = connectedDeviceName,
+                        protocol = activeProtocol,
+                        onDisconnect = onDisconnect
+                    )
+                } else if (isScanning && discoveredDevices.isEmpty()) {
+                    ScanningState(pulseScale, pulseAlpha)
+                } else if (discoveredDevices.isEmpty()) {
+                    NoDevicesState()
+                } else {
+                    DeviceList(
+                        devices = discoveredDevices,
+                        onDeviceSelected = onDeviceSelected
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color.White.copy(alpha = 0.05f))
+                    .padding(horizontal = 8.dp)
+            ) {
+                Text("Close", color = SapphoIconDefault)
+            }
+        },
+        containerColor = SapphoSurfaceLight,
+        shape = RoundedCornerShape(24.dp)
+    )
+}
+
+@Composable
+private fun ConnectedState(
+    deviceName: String?,
+    protocol: CastProtocol?,
+    onDisconnect: () -> Unit
+) {
+    // Connected device card
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = SapphoSuccess.copy(alpha = 0.12f),
+        border = BorderStroke(1.dp, SapphoSuccess.copy(alpha = 0.3f))
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(SapphoSuccess.copy(alpha = 0.2f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = iconForProtocol(protocol),
+                    contentDescription = null,
+                    tint = SapphoSuccess,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    deviceName ?: "Currently Casting",
+                    color = Color.White,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    labelForProtocol(protocol),
+                    color = SapphoSuccess,
+                    fontSize = 12.sp
+                )
+            }
+        }
+    }
+
+    // Disconnect button
+    Surface(
+        onClick = onDisconnect,
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        color = SapphoError.copy(alpha = 0.12f)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.Cast,
+                contentDescription = null,
+                tint = SapphoError,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                "Disconnect",
+                color = SapphoError,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScanningState(pulseScale: Float, pulseAlpha: Float) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            // Outer pulse ring
+            Box(
+                modifier = Modifier
+                    .size(80.dp)
+                    .scale(pulseScale)
+                    .clip(CircleShape)
+                    .background(SapphoInfo.copy(alpha = 0.1f * pulseAlpha))
+            )
+            // Inner circle
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(CircleShape)
+                    .background(
+                        Brush.linearGradient(
+                            colors = listOf(
+                                SapphoInfo.copy(alpha = 0.3f),
+                                LegacyPurpleLight.copy(alpha = 0.3f)
+                            )
+                        )
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Cast,
+                    contentDescription = null,
+                    tint = SapphoInfo,
+                    modifier = Modifier.size(28.dp)
+                )
+            }
+        }
+        Text(
+            "Scanning for devices...",
+            color = SapphoIconDefault,
+            fontSize = 14.sp
+        )
+    }
+}
+
+@Composable
+private fun NoDevicesState() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(56.dp)
+                .clip(CircleShape)
+                .background(SapphoSurface),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Cast,
+                contentDescription = null,
+                tint = SapphoIconDefault.copy(alpha = 0.5f),
+                modifier = Modifier.size(28.dp)
+            )
+        }
+        Text(
+            "No devices found",
+            color = SapphoIconDefault,
+            fontWeight = FontWeight.Medium
+        )
+        Text(
+            "Make sure your Cast, Roku, Kodi, or\nAirPlay device is on the same network",
+            color = SapphoIconDefault.copy(alpha = 0.7f),
+            fontSize = 12.sp,
+            textAlign = TextAlign.Center,
+            lineHeight = 18.sp
+        )
+    }
+}
+
+@Composable
+private fun DeviceList(
+    devices: List<CastDevice>,
+    onDeviceSelected: (CastDevice) -> Unit
+) {
+    // Group by protocol for visual organization
+    val grouped = devices.groupBy { it.protocol }
+    val protocolOrder = listOf(
+        CastProtocol.CHROMECAST,
+        CastProtocol.ROKU,
+        CastProtocol.KODI,
+        CastProtocol.AIRPLAY
+    )
+
+    protocolOrder.forEach { protocol ->
+        val protocolDevices = grouped[protocol] ?: return@forEach
+        protocolDevices.forEach { device ->
+            DeviceRow(
+                device = device,
+                onClick = { onDeviceSelected(device) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun DeviceRow(
+    device: CastDevice,
+    onClick: () -> Unit
+) {
+    val (icon, gradientColors, tint, typeLabel) = deviceVisuals(device)
+
+    Surface(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(14.dp),
+        color = SapphoSurface
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(14.dp)
+        ) {
+            // Device icon with gradient background
+            Box(
+                modifier = Modifier
+                    .size(46.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Brush.linearGradient(colors = gradientColors)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = tint,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    device.name,
+                    color = Color.White,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        typeLabel,
+                        color = SapphoIconDefault,
+                        fontSize = 12.sp
+                    )
+                    if (device.protocol == CastProtocol.AIRPLAY) {
+                        Text(
+                            "experimental",
+                            color = SapphoWarning.copy(alpha = 0.8f),
+                            fontSize = 10.sp,
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
+                }
+            }
+
+            // Arrow indicator
+            Icon(
+                imageVector = Icons.Default.PlayArrow,
+                contentDescription = null,
+                tint = SapphoIconDefault,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+    }
+}
+
+// -- Visual helpers --
+
+private fun iconForProtocol(protocol: CastProtocol?): ImageVector {
+    return when (protocol) {
+        CastProtocol.CHROMECAST -> Icons.Default.Cast
+        CastProtocol.ROKU -> Icons.Default.Tv
+        CastProtocol.KODI -> Icons.Default.DesktopWindows
+        CastProtocol.AIRPLAY -> Icons.Default.Speaker
+        null -> Icons.Default.Cast
+    }
+}
+
+private fun labelForProtocol(protocol: CastProtocol?): String {
+    return when (protocol) {
+        CastProtocol.CHROMECAST -> "Casting via Chromecast"
+        CastProtocol.ROKU -> "Casting via Roku"
+        CastProtocol.KODI -> "Casting via Kodi"
+        CastProtocol.AIRPLAY -> "Casting via AirPlay"
+        null -> "Casting audio to this device"
+    }
+}
+
+private data class DeviceVisuals(
+    val icon: ImageVector,
+    val gradientColors: List<Color>,
+    val tint: Color,
+    val typeLabel: String
+)
+
+private fun deviceVisuals(device: CastDevice): DeviceVisuals {
+    return when (device.protocol) {
+        CastProtocol.CHROMECAST -> {
+            val isTV = device.name.contains("TV", ignoreCase = true)
+            val isSpeaker = device.name.contains("Speaker", ignoreCase = true) ||
+                    device.name.contains("Home", ignoreCase = true) ||
+                    device.name.contains("Nest", ignoreCase = true)
+            DeviceVisuals(
+                icon = Icons.Default.Cast,
+                gradientColors = when {
+                    isTV -> listOf(LegacyPurpleLight.copy(alpha = 0.3f), SapphoInfo.copy(alpha = 0.2f))
+                    isSpeaker -> listOf(SapphoSuccess.copy(alpha = 0.3f), LegacyBlueLight.copy(alpha = 0.2f))
+                    else -> listOf(SapphoInfo.copy(alpha = 0.3f), LegacyPurpleLight.copy(alpha = 0.2f))
+                },
+                tint = when {
+                    isTV -> LegacyPurpleLight
+                    isSpeaker -> SapphoSuccess
+                    else -> SapphoInfo
+                },
+                typeLabel = when {
+                    isTV -> "Smart TV"
+                    isSpeaker -> "Smart Speaker"
+                    else -> "Cast Device"
+                }
+            )
+        }
+        CastProtocol.ROKU -> DeviceVisuals(
+            icon = Icons.Default.Tv,
+            gradientColors = listOf(LegacyPurpleLight.copy(alpha = 0.3f), SapphoInfo.copy(alpha = 0.2f)),
+            tint = LegacyPurpleLight,
+            typeLabel = "Roku"
+        )
+        CastProtocol.KODI -> DeviceVisuals(
+            icon = Icons.Default.DesktopWindows,
+            gradientColors = listOf(SapphoInfo.copy(alpha = 0.3f), SapphoSuccess.copy(alpha = 0.2f)),
+            tint = SapphoInfo,
+            typeLabel = "Kodi / Fire TV"
+        )
+        CastProtocol.AIRPLAY -> DeviceVisuals(
+            icon = Icons.Default.Speaker,
+            gradientColors = listOf(SapphoSuccess.copy(alpha = 0.3f), LegacyBlueLight.copy(alpha = 0.2f)),
+            tint = SapphoSuccess,
+            typeLabel = "AirPlay"
+        )
+    }
+}

--- a/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
+++ b/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
@@ -20,6 +20,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -156,6 +157,16 @@ object NetworkModule {
             .connectTimeout(60, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
             .writeTimeout(60, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    @Named("localNetwork")
+    fun provideLocalOkHttpClient(): OkHttpClient {
+        return OkHttpClient.Builder()
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
             .build()
     }
 

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerViewModel.kt
@@ -12,6 +12,7 @@ import com.sappho.audiobooks.download.DownloadManager
 import com.sappho.audiobooks.service.AudioPlaybackService
 import com.sappho.audiobooks.service.PlayerState
 import com.sappho.audiobooks.cast.CastHelper
+import com.sappho.audiobooks.cast.CastManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -25,7 +26,8 @@ class PlayerViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val sharedPlayerState: PlayerState,
     private val downloadManager: DownloadManager,
-    private val castHelper: CastHelper
+    private val castHelper: CastHelper,
+    private val castManager: CastManager
 ) : AndroidViewModel(application) {
 
     private val _audiobook = MutableStateFlow<Audiobook?>(null)
@@ -76,15 +78,15 @@ class PlayerViewModel @Inject constructor(
             book?.let {
 
                 // Check if we're currently casting
-                if (castHelper.isCasting()) {
+                if (castManager.isCasting()) {
                     val serverUrl = authRepository.getServerUrlSync()
                     if (serverUrl != null) {
-                        // Load the new audiobook on the Cast device
-                        castHelper.castAudiobook(
+                        // Load the new audiobook on the cast device
+                        castManager.castAudiobook(
                             audiobook = it,
                             streamUrl = "$serverUrl/api/audiobooks/${it.id}/stream",
                             coverUrl = if (it.coverImage != null) com.sappho.audiobooks.util.buildCoverUrl(serverUrl, it.id) else null,
-                            currentPosition = actualStartPosition.toLong()
+                            positionSeconds = actualStartPosition.toLong()
                         )
                         // Also update the shared player state with the new audiobook info
                         sharedPlayerState.updateAudiobook(it)

--- a/app/src/test/java/com/sappho/audiobooks/presentation/player/PlayerViewModelTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/presentation/player/PlayerViewModelTest.kt
@@ -9,6 +9,7 @@ import com.sappho.audiobooks.domain.model.Audiobook
 import com.sappho.audiobooks.service.PlayerState
 import com.sappho.audiobooks.download.DownloadManager
 import com.sappho.audiobooks.cast.CastHelper
+import com.sappho.audiobooks.cast.CastManager
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -39,6 +40,7 @@ class PlayerViewModelTest {
     private lateinit var sharedPlayerState: PlayerState
     private lateinit var downloadManager: DownloadManager
     private lateinit var castHelper: CastHelper
+    private lateinit var castManager: CastManager
     private lateinit var viewModel: PlayerViewModel
 
     @Before
@@ -50,16 +52,18 @@ class PlayerViewModelTest {
         sharedPlayerState = mockk(relaxed = true)
         downloadManager = mockk(relaxed = true)
         castHelper = mockk(relaxed = true)
+        castManager = mockk(relaxed = true)
 
         every { authRepository.getServerUrlSync() } returns "https://test.com"
-        
+
         viewModel = PlayerViewModel(
             application = application,
             api = api,
             authRepository = authRepository,
             sharedPlayerState = sharedPlayerState,
             downloadManager = downloadManager,
-            castHelper = castHelper
+            castHelper = castHelper,
+            castManager = castManager
         )
     }
 


### PR DESCRIPTION
## Summary

Closes #338

- Introduces a `CastTarget` interface and `CastManager` orchestrator for protocol-agnostic casting across Chromecast, Roku (ECP), Kodi (JSON-RPC), and AirPlay (HTTP)
- Extracts the 400-line inline cast dialog from `PlayerActivity` into a reusable `CastDialog` composable showing all discovered devices grouped by protocol
- Adds SSDP multicast discovery for Roku/Kodi and mDNS discovery for AirPlay devices
- Kodi candidates are verified via JSON-RPC ping to avoid false positives from generic UPnP MediaRenderer responses (e.g. Samsung TVs)
- AirPlay support is marked as experimental (AirPlay 2 encrypted devices may not work)
- Existing Chromecast functionality is fully preserved via a thin `ChromecastTarget` adapter around `CastHelper`

## New files
- `cast/CastTarget.kt` — Interface, `CastProtocol` enum, `CastDevice` data class
- `cast/CastManager.kt` — Singleton orchestrator
- `cast/targets/` — `ChromecastTarget`, `RokuCastTarget`, `KodiCastTarget`, `AirPlayCastTarget`
- `cast/discovery/` — `SsdpDiscovery`, `MdnsDiscovery`
- `cast/ui/CastDialog.kt` — Unified device picker

## Test plan
- [ ] Open player → tap Cast → unified dialog appears with scanning animation
- [ ] Chromecast devices discovered and work identically to before
- [ ] Roku devices discovered via SSDP on local network
- [ ] Kodi instances discovered (or verify no false positives from non-Kodi UPnP devices)
- [ ] AirPlay devices discovered via mDNS (marked experimental)
- [ ] Transport controls (play/pause) work when casting
- [ ] Disconnect returns cleanly to local playback
- [ ] `./gradlew test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)