### PR TITLE
Modernize library UI: cover grids, marquee text, rating badges

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 38
-        versionName = "0.9.20"
+        versionCode = 39
+        versionName = "0.9.21"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- Convert author detail books from horizontal lists to cover art grids
- Add marquee scrolling (12dp velocity) for long titles across series list, author list, series detail, author detail, genre detail, and all books views
- Add rating badge overlay on covers in all books grid (dark pill, bottom-right, gold star + white text)
- Clean up series list (remove hours stat) and author list (remove mini covers, book count, time, series count)
- Move Catch Me Up button to subtle icon in series detail header top-right corner
- Move star rating inline under series title/author
- Add title, author, and rating display to genre detail and all books book grids
- Fix hardcoded Color.White references to use SapphoText theme colors

## Test plan
- [ ] Open Library → Series list: verify no hours stat shown, long titles marquee
- [ ] Open Library → Authors list: verify no covers/stats, long names/genres marquee
- [ ] Open author detail: verify books show as cover grids with "Series" headers, not horizontal scrolls
- [ ] Open series detail: verify Catch Me Up is small icon top-right, rating inline under title
- [ ] Open genre detail: verify titles marquee, ratings shown
- [ ] Open All Books: verify title, author below covers and rating badge on cover art
- [ ] Verify marquee speed feels natural (12dp/s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)