### PR TITLE
Add file management to audiobook detail screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 40
-        versionName = "0.9.22"
+        versionCode = 41
+        versionName = "0.9.23"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
@@ -120,6 +120,13 @@ interface SapphoApi {
     @GET("api/audiobooks/{id}/directory-files")
     suspend fun getFiles(@Path("id") audiobookId: Int): Response<List<DirectoryFile>>
 
+    // Delete file from audiobook directory (admin only)
+    @HTTP(method = "DELETE", path = "api/audiobooks/{id}/files", hasBody = true)
+    suspend fun deleteFile(
+        @Path("id") audiobookId: Int,
+        @Body body: DeleteFileRequest
+    ): Response<Map<String, String>>
+
     // Delete
     @DELETE("api/audiobooks/{id}")
     suspend fun deleteAudiobook(@Path("id") audiobookId: Int): Response<Unit>

--- a/app/src/main/java/com/sappho/audiobooks/domain/model/Audiobook.kt
+++ b/app/src/main/java/com/sappho/audiobooks/domain/model/Audiobook.kt
@@ -75,6 +75,11 @@ data class DirectoryFile(
     val extension: String
 )
 
+// Request body for DELETE /api/audiobooks/{id}/files
+data class DeleteFileRequest(
+    @SerializedName("file_path") val filePath: String
+)
+
 data class AuthResponse(
     val token: String? = null,
     val user: User? = null,


### PR DESCRIPTION
## Summary
- Show all files in audiobook directory (covers, NFOs, etc.) in the Files section, not just audio files
- Add delete button (X) next to each file row, visible only for admin users
- Confirmation dialog before file deletion with error handling and auto-refreshing file list
- Bump version to 0.9.23 (41)

Depends on server PR: https://github.com/mondominator/sappho/pull/360

## Test plan
- [ ] Open a book detail → Files section shows all files (audio + covers + other)
- [ ] Non-admin user: no X buttons visible
- [ ] Admin user: X buttons visible, tapping shows confirmation dialog
- [ ] Confirming deletion removes the file and refreshes the list
- [ ] Cancelling the dialog does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)