### PR TITLE
Fix mini player behind nav bar, add Convert to M4B

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 42
-        versionName = "0.9.24"
+        versionCode = 43
+        versionName = "0.9.25"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
@@ -135,6 +135,10 @@ interface SapphoApi {
     @POST("api/audiobooks/{id}/refresh-metadata")
     suspend fun refreshMetadata(@Path("id") audiobookId: Int): Response<RefreshMetadataResponse>
 
+    // Convert to M4B
+    @POST("api/audiobooks/{id}/convert-to-m4b")
+    suspend fun convertToM4B(@Path("id") audiobookId: Int): Response<MessageResponse>
+
     // User Profile
     @GET("api/profile")
     suspend fun getProfile(): Response<User>

--- a/app/src/main/java/com/sappho/audiobooks/domain/model/Audiobook.kt
+++ b/app/src/main/java/com/sappho/audiobooks/domain/model/Audiobook.kt
@@ -26,6 +26,7 @@ data class Audiobook(
     val description: String?,
     @SerializedName("cover_image") val coverImage: String?,
     @SerializedName("file_count") val fileCount: Int = 0,
+    @SerializedName("file_path") val filePath: String? = null,
     @SerializedName("is_multi_file") val isMultiFile: Int? = null,
     @SerializedName("created_at") val createdAt: String? = null,
     val progress: Progress?,

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/MinimizedPlayerBar.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/MinimizedPlayerBar.kt
@@ -96,11 +96,14 @@ fun MinimizedPlayerBar(
         Surface(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(80.dp),
+                .navigationBarsPadding(),
             color = SapphoSurfaceLight,
             shadowElevation = 8.dp
         ) {
-            Column(modifier = Modifier.fillMaxSize()) {
+            Column(modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+            ) {
                 // Custom progress slider at top
                 var sliderWidth by remember { mutableFloatStateOf(0f) }
                 val density = androidx.compose.ui.platform.LocalDensity.current


### PR DESCRIPTION
## Summary
- **Fix mini player overlap**: Add `navigationBarsPadding()` to MinimizedPlayerBar so it sits above the system navigation bar on phones with 3-button navigation (instead of being hidden behind it)
- **Add Convert to M4B**: Add "Convert to M4B" option to audiobook detail overflow menu, with progress spinner and result snackbar. Hidden for files already in M4B format.

## Test plan
- [ ] On a phone with 3-button navigation, verify the mini player is fully visible above the nav bar
- [ ] On a phone with gesture navigation, verify the mini player still looks correct
- [ ] Open a non-M4B audiobook detail → overflow menu → verify "Convert to M4B" appears
- [ ] Open an M4B audiobook detail → overflow menu → verify "Convert to M4B" is NOT shown
- [ ] Tap Convert to M4B → verify spinner shows and result snackbar appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)