### PR TITLE
Improve batch delete error messages

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 43
-        versionName = "0.9.25"
+        versionCode = 44
+        versionName = "0.9.26"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryViewModel.kt
@@ -456,7 +456,14 @@ class LibraryViewModel @Inject constructor(
                     exitSelectionMode()
                     onResult(true, "Deleted $count books")
                 } else {
-                    onResult(false, "Failed to delete books")
+                    val errorBody = response.errorBody()?.string()
+                    Log.e("LibraryViewModel", "Batch delete failed: ${response.code()} - $errorBody")
+                    val errorMessage = when (response.code()) {
+                        403 -> "Admin access required"
+                        400 -> "Invalid request"
+                        else -> "Failed to delete (${response.code()})"
+                    }
+                    onResult(false, errorMessage)
                 }
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error in batch delete", e)


### PR DESCRIPTION
## Summary
- Show specific error messages for batch delete failures (403 → admin required, 400 → invalid request)
- Add error body logging for diagnosis
- Previously showed generic "Failed to delete books" for all error codes

## Test plan
- [ ] Test batch delete with admin account
- [ ] Verify specific error messages appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)