### PR TITLE
Increase upload timeout to 5 minutes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 45
-        versionName = "0.9.27"
+        versionCode = 46
+        versionName = "0.9.28"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
+++ b/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
@@ -155,8 +155,8 @@ object NetworkModule {
                 response
             }
             .connectTimeout(60, TimeUnit.SECONDS)
-            .readTimeout(60, TimeUnit.SECONDS)
-            .writeTimeout(60, TimeUnit.SECONDS)
+            .readTimeout(5, TimeUnit.MINUTES)
+            .writeTimeout(5, TimeUnit.MINUTES)
             .build()
     }
 


### PR DESCRIPTION
## Summary
- Increased OkHttp read and write timeouts from 60 seconds to 5 minutes
- Fixes "Software caused connection abort" error when uploading large audiobook files
- Connect timeout stays at 60 seconds (only the data transfer needs more time)

## Root Cause
Audiobook files (especially M4B) can be hundreds of MB. The 60-second write timeout was insufficient for uploading these files, causing the connection to be aborted mid-transfer.

## Test plan
- [ ] Upload a large audiobook file (>100MB) from Android app
- [ ] Verify normal API calls still work with reasonable response times

🤖 Generated with [Claude Code](https://claude.com/claude-code)