### PR TITLE
Add conversion progress card with polling-based tracking

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 47
-        versionName = "0.9.29"
+        versionCode = 48
+        versionName = "0.9.30"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
@@ -137,7 +137,15 @@ interface SapphoApi {
 
     // Convert to M4B
     @POST("api/audiobooks/{id}/convert-to-m4b")
-    suspend fun convertToM4B(@Path("id") audiobookId: Int): Response<MessageResponse>
+    suspend fun convertToM4B(@Path("id") audiobookId: Int): Response<ConvertToM4BResponse>
+
+    // Conversion status polling
+    @GET("api/audiobooks/{id}/conversion-status")
+    suspend fun getConversionStatus(@Path("id") audiobookId: Int): Response<com.sappho.audiobooks.domain.model.ConversionStatusResponse>
+
+    // Cancel conversion job
+    @DELETE("api/audiobooks/jobs/conversion/{jobId}")
+    suspend fun cancelConversionJob(@Path("jobId") jobId: String): Response<MessageResponse>
 
     // User Profile
     @GET("api/profile")
@@ -1163,5 +1171,12 @@ data class UpdateApiKeyRequest(
 
 data class MessageResponse(
     val message: String?,
+    val error: String?
+)
+
+data class ConvertToM4BResponse(
+    val message: String?,
+    val jobId: String?,
+    val status: String?,
     val error: String?
 )

--- a/app/src/main/java/com/sappho/audiobooks/domain/model/ConversionStatus.kt
+++ b/app/src/main/java/com/sappho/audiobooks/domain/model/ConversionStatus.kt
@@ -1,0 +1,18 @@
+package com.sappho.audiobooks.domain.model
+
+import com.google.gson.annotations.SerializedName
+
+data class ConversionStatusResponse(
+    val active: Boolean,
+    val job: ConversionJob?
+)
+
+data class ConversionJob(
+    @SerializedName("id") val jobId: String,
+    val status: String,
+    val progress: Int,
+    val message: String?,
+    @SerializedName("audiobookTitle") val audiobookTitle: String?,
+    @SerializedName("audiobookId") val audiobookId: Int?,
+    val error: String?
+)


### PR DESCRIPTION
## Summary
- **Conversion progress card**: Adds a Material 3 progress card on the audiobook detail screen that shows live conversion progress with polling
- **Polling-based tracking**: After triggering M4B conversion, polls `GET /api/audiobooks/:id/conversion-status` every 3 seconds to track progress
- **Cancel support**: Users can cancel active conversions from the progress card
- **Auto-reload**: On conversion completion, automatically reloads the audiobook to show updated M4B file info

## Changes
- `app/.../data/remote/SapphoApi.kt` — Added `getConversionStatus()`, `cancelConversionJob()` endpoints and `ConvertToM4BResponse` data class
- `app/.../domain/model/ConversionStatus.kt` — New model: `ConversionStatusResponse` and `ConversionJob`
- `app/.../presentation/detail/AudiobookDetailViewModel.kt` — Replaced fire-and-forget with polling-based progress tracking, cancel support, auto-reload on completion
- `app/.../presentation/detail/AudiobookDetailScreen.kt` — Added color-coded progress card with LinearProgressIndicator, percentage, status message, cancel button
- `app/build.gradle.kts` — Version bump to 0.9.30 (48)

## Test plan
- [ ] `./gradlew assembleDebug` builds successfully
- [ ] Trigger conversion from detail screen → progress card appears
- [ ] Card updates every 3 seconds with progress bar and status
- [ ] Cancel button works and dismisses the card
- [ ] On completion, audiobook reloads with new M4B file info
- [ ] Navigating away and back detects in-progress conversions

🤖 Generated with [Claude Code](https://claude.com/claude-code)