### PR TITLE
Fix playback starting from beginning due to progress race condition

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 52
-        versionName = "0.9.34"
+        versionCode = 53
+        versionName = "0.9.35"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerViewModel.kt
@@ -68,9 +68,22 @@ class PlayerViewModel @Inject constructor(
             }
 
             // If no explicit position was passed, use the book's saved progress
-            // This applies whether we got the book from server or from downloaded data
             if (actualStartPosition == 0 && book?.progress != null) {
                 actualStartPosition = book.progress!!.position
+            }
+
+            // Defense-in-depth: if we still have no position, fetch progress separately
+            if (actualStartPosition == 0 && book?.progress == null) {
+                try {
+                    val progressResponse = api.getProgress(audiobookId)
+                    if (progressResponse.isSuccessful) {
+                        val progress = progressResponse.body()
+                        if (progress != null && progress.position > 0) {
+                            actualStartPosition = progress.position
+                        }
+                    }
+                } catch (_: Exception) {
+                }
             }
 
             _audiobook.value = book


### PR DESCRIPTION
## Summary
- Added defense-in-depth fallback in `PlayerViewModel.loadAndStartPlayback()`: when `startPosition` is 0 and the book has no progress data, makes a separate `getProgress()` API call before starting playback
- Bumped version to 0.9.35 (versionCode 53)
- Works together with server-side fix (sappho PR) that adds progress data to `GET /api/audiobooks/:id`

## Root cause
The server's `GET /api/audiobooks/:id` endpoint didn't join `playback_progress`, so `book.progress` was always null in the player. When a user opened a book, if `startPosition` was 0 (the default), the fallback check `if (actualStartPosition == 0 && book?.progress != null)` could never succeed, and playback started from the beginning.

## Test plan
- [ ] Open a book with saved progress - should resume from saved position
- [ ] Open a book with no progress - should start from beginning (position 0)
- [ ] Test with server offline (downloaded book) - should use cached progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)