### PR TITLE
Fix progress loss when app is backgrounded after pause

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 54
-        versionName = "0.9.36"
+        versionCode = 55
+        versionName = "0.9.37"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary

- Sync progress to server immediately when playback pauses (previously relied on 10s periodic timer, losing up to 10s of progress)
- Keep service alive for 10 minutes after pause by re-asserting foreground status, preventing Android from killing it within minutes
- Add `onTaskRemoved()` override with blocking sync so progress is saved when user swipes app from recents
- Make `onDestroy()` sync blocking (`runBlocking`) instead of fire-and-forget coroutine that never completes
- Bump version to 0.9.37 (versionCode 55)

## Test plan

- [ ] Play a book for a few minutes, then pause
- [ ] Minimize the app and wait 3-4 minutes — notification should stay visible
- [ ] Reopen the app — position should be preserved at the paused location
- [ ] Wait 10+ minutes with paused playback — service should self-stop
- [ ] Swipe app from recents while paused — reopen and verify progress was saved to server

🤖 Generated with [Claude Code](https://claude.com/claude-code)