### PR TITLE
Remove title and author text from book cards

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionDetailScreen.kt
@@ -519,27 +519,7 @@ private fun CollectionBookItem(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text(
-                text = book.title,
-                style = MaterialTheme.typography.labelMedium,
-                color = SapphoText,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                textAlign = TextAlign.Center
-            )
-
-            book.author?.let {
-                Text(
-                    text = it,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = SapphoIconDefault,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    textAlign = TextAlign.Center
-                )
-            }
-
-            // Rating below author - prefer user rating, fall back to average rating
+            // Rating - prefer user rating, fall back to average rating
             val displayRating = book.userRating ?: book.averageRating
             if (displayRating != null && displayRating > 0) {
                 Row(

--- a/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
@@ -427,10 +427,8 @@ fun AudiobookCard(
         serverUrl?.let { com.sappho.audiobooks.util.buildCoverUrl(it, book.id, com.sappho.audiobooks.util.COVER_WIDTH_THUMBNAIL) }
     }
     
-    // Calculate responsive font sizes based on card size
+    // Calculate responsive font size for placeholder
     val placeholderFontSize = (cardSize.value * 0.15f).sp
-    val titleFontSize = (cardSize.value * 0.10f).sp
-    val authorFontSize = (cardSize.value * 0.08f).sp
     
     val cardTapHaptic = HapticPatterns.cardTap()
 
@@ -560,31 +558,6 @@ fun AudiobookCard(
                 }
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Title
-            Text(
-                text = book.title,
-                fontSize = titleFontSize,
-                fontWeight = FontWeight.Medium,
-                maxLines = 1,
-                color = SapphoText,
-                modifier = Modifier.basicMarquee(
-                    iterations = Int.MAX_VALUE,
-                    initialDelayMillis = 2000,
-                    velocity = 30.dp
-                )
-            )
-
-            // Author
-            if (book.author != null) {
-                Text(
-                    text = book.author,
-                    fontSize = authorFontSize,
-                    maxLines = 1,
-                    color = SapphoIconDefault
-                )
-            }
         }
 }
 

--- a/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
@@ -2524,25 +2524,6 @@ fun AuthorBookCard(
             }
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Text(
-            text = book.title,
-            fontSize = 13.sp,
-            fontWeight = FontWeight.Medium,
-            color = Color.White,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            lineHeight = 16.sp
-        )
-
-        if (book.duration != null) {
-            Text(
-                text = "${book.duration / 3600}h ${(book.duration % 3600) / 60}m",
-                fontSize = 11.sp,
-                color = SapphoIconDefault
-            )
-        }
     }
 }
 

--- a/app/src/main/java/com/sappho/audiobooks/presentation/readinglist/ReadingListScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/readinglist/ReadingListScreen.kt
@@ -212,23 +212,6 @@ fun ReadingListBookItem(
             }
         }
 
-        Spacer(modifier = Modifier.height(6.dp))
-
-        Text(
-            text = book.title,
-            style = MaterialTheme.typography.labelMedium,
-            color = Color.White,
-            maxLines = 2
-        )
-
-        book.author?.let {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.labelSmall,
-                color = SapphoIconDefault,
-                maxLines = 1
-            )
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Remove title, author, and duration text below book cover art on all grid views
- Cards now show only the cover image for a cleaner browsing experience
- Affects: Home, Library, Collections, Reading List

## Test plan

- [ ] Home screen book cards show covers only
- [ ] Library author/series book cards show covers only
- [ ] Collection detail cards show covers only
- [ ] Reading list cards show covers only

🤖 Generated with [Claude Code](https://claude.com/claude-code)