### PR TITLE
Remove title and author text from book cards

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 55
-        versionName = "0.9.37"
+        versionCode = 56
+        versionName = "0.9.38"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- Remove title and author text overlays from book cards, showing only the cover image
- Fix progress loss when app is backgrounded after pause
- Bump version to 0.9.38 (56) for Play Store deploy

## Test plan
- [ ] Verify book cards display cover images without text overlays
- [ ] Verify progress is not lost when backgrounding the app after pausing
- [ ] Verify Play Store deploy succeeds with new version code

🤖 Generated with [Claude Code](https://claude.com/claude-code)