### PR TITLE
Only save offline progress when playing downloaded files

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 57
-        versionName = "0.9.39"
+        versionCode = 58
+        versionName = "0.9.40"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- Root cause: `syncProgress()` was saving offline progress on ANY API exception, even transient network hiccups during streaming. Since ExoPlayer buffers ahead, playback works fine but the "Pending sync" banner gets stuck.
- Now only saves pending progress when `isPlayingLocalFile` is true (playing a downloaded file offline). For streaming, transient errors are ignored — the next 10-second sync cycle handles it.
- Fixes `syncPendingProgress()` which was breaking on first failure instead of trying all pending items
- Same guard applied to `onTaskRemoved()` and `onDestroy()` lifecycle methods
- Bump version to 0.9.40 (58)

## Test plan
- [ ] Stream an audiobook — verify no "Pending sync" banner appears even if network is flaky
- [ ] Play a downloaded audiobook in airplane mode — verify progress is saved locally and syncs when back online
- [ ] Verify Play Store deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)