### PR TITLE
Clear stale pending progress when server is reachable

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 58
-        versionName = "0.9.40"
+        versionCode = 59
+        versionName = "0.9.41"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/download/DownloadManager.kt
+++ b/app/src/main/java/com/sappho/audiobooks/download/DownloadManager.kt
@@ -402,6 +402,13 @@ class DownloadManager @Inject constructor(
         savePendingProgress()
     }
 
+    fun clearAllPendingProgress() {
+        if (_pendingProgress.value.isEmpty()) return
+        Log.d(TAG, "Clearing all pending progress (${_pendingProgress.value.size} items)")
+        _pendingProgress.value = emptyMap()
+        savePendingProgress()
+    }
+
     fun hasPendingProgress(): Boolean {
         return _pendingProgress.value.isNotEmpty()
     }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeViewModel.kt
@@ -176,7 +176,10 @@ class HomeViewModel @Inject constructor(
                 if (finishedResponse?.isSuccessful == true) {
                     _finished.value = (finishedResponse.body() ?: emptyList()).withFavoriteStatus()
                 }
-                // Data loaded successfully from server — clear any stale sync error
+                // Data loaded successfully from server — clear any stale sync state.
+                // Pending progress items are now stale since the server has the real
+                // position from successful streaming syncs.
+                downloadManager.clearAllPendingProgress()
                 syncStatusManager.updateSyncStatus(lastSyncSuccess = true)
             } catch (e: Exception) {
                 } finally {


### PR DESCRIPTION
## Summary
- Server logs confirm zero POST requests to `/progress` — the sync worker wasn't clearing stale items
- When `loadData()` succeeds, the server is confirmed reachable and already has the real position from streaming syncs. Stale pending progress items are now cleared immediately.
- Adds `clearAllPendingProgress()` to DownloadManager
- Bump version to 0.9.41 (59)

## Context
Previous PRs (#202, #203) fixed the root cause (not creating new pending items during streaming) but didn't address pre-existing stale items persisted in `pending_progress.json` on user devices.

## Test plan
- [ ] Update app and verify "Pending sync" banner disappears on home screen load
- [ ] Verify Play Store deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)