### PR TITLE
Show live player position on detail screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 59
-        versionName = "0.9.41"
+        versionCode = 60
+        versionName = "0.9.42"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.sappho.audiobooks.presentation.detail
 
+import com.sappho.audiobooks.domain.model.Progress
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -412,8 +413,12 @@ fun AudiobookDetailScreen(
                                 }
                             }
 
-                            // Progress bar overlay at bottom
-                            val progressData = progress
+                            // Progress bar overlay at bottom - use live position when this book is playing
+                            val progressData = if (isThisBookLoaded && currentPosition > 0) {
+                                progress?.copy(position = currentPosition.toInt()) ?: Progress(position = currentPosition.toInt(), completed = 0)
+                            } else {
+                                progress
+                            }
                             val hasProgress = progressData != null &&
                                               book.duration != null &&
                                               book.duration > 0 &&
@@ -1024,7 +1029,13 @@ fun AudiobookDetailScreen(
                     }
 
                     // Progress Section (above About)
-                    progress?.let { prog ->
+                    // Use live player position when this book is loaded, otherwise server progress
+                    val displayProgress = if (isThisBookLoaded && currentPosition > 0) {
+                        progress?.copy(position = currentPosition.toInt()) ?: Progress(position = currentPosition.toInt(), completed = 0)
+                    } else {
+                        progress
+                    }
+                    displayProgress?.let { prog ->
                         if (prog.position > 0 || prog.completed == 1) {
                             Spacer(modifier = Modifier.height(24.dp))
 


### PR DESCRIPTION
## Summary
- When the current book is loaded in the player, the detail screen now shows the live `currentPosition` from playerState instead of stale server-fetched progress
- Fixes issue where returning to the detail screen after pausing showed old synced position (e.g. 1:55) instead of actual position (e.g. 3:22)
- Applies to both the progress section ("Xh Xm listened") and the progress bar overlay
- Bump version to 0.9.42 (60)

## Test plan
- [ ] Start playing a book and pause partway through
- [ ] Lock phone, then unlock and return to the book detail screen
- [ ] Verify the progress time matches the actual playback position immediately
- [ ] Navigate away and back — verify it still shows correct position

🤖 Generated with [Claude Code](https://claude.com/claude-code)