### PR TITLE
Fix stale player state on resume

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 60
-        versionName = "0.9.42"
+        versionCode = 61
+        versionName = "0.9.43"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
@@ -546,14 +546,8 @@ fun PlayerScreen(
                                             }
                                         }
                                     } else {
-                                        // Control local playback
-                                        val service = AudioPlaybackService.instance
-                                        val playerHandled = service?.togglePlayPause() ?: false
-                                        if (!playerHandled) {
-                                            // Service was killed or player is null (e.g., after vehicle disconnect)
-                                            // Restart playback from current position
-                                            viewModel.loadAndStartPlayback(audiobookId, currentPosition.toInt())
-                                        }
+                                        // Control local playback with staleness guard
+                                        viewModel.togglePlayPauseWithGuard(audiobookId)
                                     }
                                 },
                             contentAlignment = Alignment.Center

--- a/app/src/main/java/com/sappho/audiobooks/service/PlayerState.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/PlayerState.kt
@@ -32,6 +32,13 @@ class PlayerState @Inject constructor() {
     private val _bufferedPosition = MutableStateFlow(0L)
     val bufferedPosition: StateFlow<Long> = _bufferedPosition
 
+    private val _lastActiveTimestamp = MutableStateFlow(0L)
+    val lastActiveTimestamp: StateFlow<Long> = _lastActiveTimestamp
+
+    fun updateLastActiveTimestamp() {
+        _lastActiveTimestamp.value = System.currentTimeMillis()
+    }
+
     fun updateAudiobook(audiobook: Audiobook?) {
         _currentAudiobook.value = audiobook
     }
@@ -73,5 +80,6 @@ class PlayerState @Inject constructor() {
         _playbackSpeed.value = 1.0f
         _sleepTimerRemaining.value = null
         _bufferedPosition.value = 0L
+        _lastActiveTimestamp.value = 0L
     }
 }

--- a/app/src/test/java/com/sappho/audiobooks/presentation/player/PlayerViewModelTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/presentation/player/PlayerViewModelTest.kt
@@ -6,15 +6,22 @@ import com.google.common.truth.Truth.assertThat
 import com.sappho.audiobooks.data.remote.SapphoApi
 import com.sappho.audiobooks.data.repository.AuthRepository
 import com.sappho.audiobooks.domain.model.Audiobook
+import com.sappho.audiobooks.domain.model.Progress
+import com.sappho.audiobooks.service.AudioPlaybackService
 import com.sappho.audiobooks.service.PlayerState
 import com.sappho.audiobooks.download.DownloadManager
 import com.sappho.audiobooks.cast.CastHelper
 import com.sappho.audiobooks.cast.CastManager
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -49,7 +56,7 @@ class PlayerViewModelTest {
         application = mockk(relaxed = true)
         api = mockk(relaxed = true)
         authRepository = mockk(relaxed = true)
-        sharedPlayerState = mockk(relaxed = true)
+        sharedPlayerState = PlayerState()
         downloadManager = mockk(relaxed = true)
         castHelper = mockk(relaxed = true)
         castManager = mockk(relaxed = true)
@@ -138,5 +145,188 @@ class PlayerViewModelTest {
 
         // Then
         assertThat(viewModel.chapters.first()).isEqualTo(chapters)
+    }
+
+    // --- checkForUpdatedProgress tests ---
+
+    @Test
+    fun `checkForUpdatedProgress updates position when service is dead`() = runTest {
+        // Given - service is null (dead), local position is 100
+        sharedPlayerState.updatePosition(100L)
+        val progress = Progress(position = 500, completed = 0)
+        coEvery { api.getProgress(1) } returns Response.success(progress)
+
+        // Ensure AudioPlaybackService.instance is null (default in tests)
+        mockkObject(AudioPlaybackService.Companion)
+        every { AudioPlaybackService.instance } returns null
+
+        // When
+        viewModel.checkForUpdatedProgress(1)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then - PlayerState should be updated directly
+        assertThat(sharedPlayerState.currentPosition.value).isEqualTo(500L)
+
+        unmockkObject(AudioPlaybackService.Companion)
+    }
+
+    @Test
+    fun `checkForUpdatedProgress does not interrupt active playback`() = runTest {
+        // Given - service is playing, local position is 100
+        sharedPlayerState.updatePosition(100L)
+        val progress = Progress(position = 500, completed = 0)
+        coEvery { api.getProgress(1) } returns Response.success(progress)
+
+        val mockService = mockk<AudioPlaybackService>(relaxed = true)
+        every { mockService.isCurrentlyPlaying() } returns true
+
+        mockkObject(AudioPlaybackService.Companion)
+        every { AudioPlaybackService.instance } returns mockService
+
+        // When
+        viewModel.checkForUpdatedProgress(1)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then - position should NOT be changed, seekTo should NOT be called
+        assertThat(sharedPlayerState.currentPosition.value).isEqualTo(100L)
+        verify(exactly = 0) { mockService.seekTo(any()) }
+
+        unmockkObject(AudioPlaybackService.Companion)
+    }
+
+    @Test
+    fun `checkForUpdatedProgress skips completed books`() = runTest {
+        // Given - server says book is completed
+        sharedPlayerState.updatePosition(100L)
+        val progress = Progress(position = 500, completed = 1)
+        coEvery { api.getProgress(1) } returns Response.success(progress)
+
+        mockkObject(AudioPlaybackService.Companion)
+        every { AudioPlaybackService.instance } returns null
+
+        // When
+        viewModel.checkForUpdatedProgress(1)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then - position should NOT be updated
+        assertThat(sharedPlayerState.currentPosition.value).isEqualTo(100L)
+
+        unmockkObject(AudioPlaybackService.Companion)
+    }
+
+    @Test
+    fun `checkForUpdatedProgress handles network failure gracefully`() = runTest {
+        // Given - network fails
+        sharedPlayerState.updatePosition(100L)
+        coEvery { api.getProgress(1) } throws Exception("Network error")
+
+        mockkObject(AudioPlaybackService.Companion)
+        every { AudioPlaybackService.instance } returns null
+
+        // When
+        viewModel.checkForUpdatedProgress(1)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then - position unchanged, no crash
+        assertThat(sharedPlayerState.currentPosition.value).isEqualTo(100L)
+
+        unmockkObject(AudioPlaybackService.Companion)
+    }
+
+    @Test
+    fun `checkForUpdatedProgress seeks service when paused and position differs`() = runTest {
+        // Given - service alive but paused, positions differ by >2s
+        sharedPlayerState.updatePosition(100L)
+        val progress = Progress(position = 200, completed = 0)
+        coEvery { api.getProgress(1) } returns Response.success(progress)
+
+        val mockService = mockk<AudioPlaybackService>(relaxed = true)
+        every { mockService.isCurrentlyPlaying() } returns false
+
+        mockkObject(AudioPlaybackService.Companion)
+        every { AudioPlaybackService.instance } returns mockService
+
+        // When
+        viewModel.checkForUpdatedProgress(1)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then - service should be seeked to server position
+        verify { mockService.seekTo(200L) }
+
+        unmockkObject(AudioPlaybackService.Companion)
+    }
+
+    // --- togglePlayPauseWithGuard tests ---
+
+    @Test
+    fun `togglePlayPauseWithGuard pauses immediately even when stale`() = runTest {
+        // Given - service is currently playing (pause should be instant)
+        val mockService = mockk<AudioPlaybackService>(relaxed = true)
+        every { mockService.isCurrentlyPlaying() } returns true
+        every { mockService.togglePlayPause() } returns true
+
+        mockkObject(AudioPlaybackService.Companion)
+        every { AudioPlaybackService.instance } returns mockService
+
+        // When
+        viewModel.togglePlayPauseWithGuard(1)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then - togglePlayPause called immediately, no API call
+        verify { mockService.togglePlayPause() }
+        coVerify(exactly = 0) { api.getProgress(any()) }
+
+        unmockkObject(AudioPlaybackService.Companion)
+    }
+
+    @Test
+    fun `togglePlayPauseWithGuard fetches server progress when stale`() = runTest {
+        // Given - lastActiveTimestamp is 0 (stale), service exists but paused
+        // sharedPlayerState.lastActiveTimestamp defaults to 0L (stale)
+        sharedPlayerState.updatePosition(100L)
+        val progress = Progress(position = 500, completed = 0)
+        coEvery { api.getProgress(1) } returns Response.success(progress)
+
+        val mockService = mockk<AudioPlaybackService>(relaxed = true)
+        every { mockService.isCurrentlyPlaying() } returns false
+        every { mockService.togglePlayPause() } returns true
+
+        mockkObject(AudioPlaybackService.Companion)
+        every { AudioPlaybackService.instance } returns mockService
+
+        // When
+        viewModel.togglePlayPauseWithGuard(1)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then - should have fetched progress and seeked before toggling
+        coVerify { api.getProgress(1) }
+        verify { mockService.seekTo(500L) }
+        verify { mockService.togglePlayPause() }
+
+        unmockkObject(AudioPlaybackService.Companion)
+    }
+
+    @Test
+    fun `togglePlayPauseWithGuard skips fetch when recently active`() = runTest {
+        // Given - recently active (not stale)
+        sharedPlayerState.updateLastActiveTimestamp() // sets to current time
+        sharedPlayerState.updatePosition(100L)
+
+        val mockService = mockk<AudioPlaybackService>(relaxed = true)
+        every { mockService.isCurrentlyPlaying() } returns false
+        every { mockService.togglePlayPause() } returns true
+
+        mockkObject(AudioPlaybackService.Companion)
+        every { AudioPlaybackService.instance } returns mockService
+
+        // When
+        viewModel.togglePlayPauseWithGuard(1)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then - no API call, toggle directly
+        coVerify(exactly = 0) { api.getProgress(any()) }
+        verify { mockService.togglePlayPause() }
+
+        unmockkObject(AudioPlaybackService.Companion)
     }
 }


### PR DESCRIPTION
## Summary
- **Staleness guard on play button**: When the player has been idle >30 seconds, fetches server progress before resuming playback to avoid starting from the wrong position
- **Resume reconciliation**: `checkForUpdatedProgress()` now handles service-dead case by updating PlayerState directly, checks actual ExoPlayer state instead of stale `isPlaying` flag, and uses a tighter 2-second threshold
- **Longer pause timeout**: Bumps notification/service timeout from 10 to 30 minutes so the service stays alive longer after pausing
- **Version bump**: 0.9.42 → 0.9.43 (versionCode 60 → 61)

## Test plan
- [ ] Play an audiobook, let it play for a minute, pause via headphones
- [ ] Wait 30+ seconds, reopen the app — player should show correct position (not 0)
- [ ] Listen on the web app, advance the position, then open the phone app — player should sync to server position
- [ ] Pause and wait — notification should stay visible for 30 minutes
- [ ] After service timeout, reopen player — should show server position, not 0
- [ ] Verify pause is always immediate (no delay when pressing pause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)