### PR TITLE
Preserve player display state when service times out

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 61
-        versionName = "0.9.43"
+        versionCode = 62
+        versionName = "0.9.44"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerViewModel.kt
@@ -180,6 +180,16 @@ class PlayerViewModel @Inject constructor(
                     if (serverPosition > 0 && serverPosition != localPosition) {
                         sharedPlayerState.updatePosition(serverPosition)
                     }
+                    // Restore duration if missing (e.g. PlayerState was fully cleared)
+                    if (sharedPlayerState.duration.value == 0L) {
+                        val book = _audiobook.value
+                        if (book?.duration != null && book.duration > 0) {
+                            sharedPlayerState.updateDuration(book.duration.toLong())
+                        }
+                    }
+                    // Mark state as freshly reconciled so togglePlayPauseWithGuard
+                    // doesn't redundantly fetch progress again
+                    sharedPlayerState.updateLastActiveTimestamp()
                     return@launch
                 }
 

--- a/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
@@ -1654,7 +1654,7 @@ class AudioPlaybackService : MediaLibraryService() {
         positionUpdateJob?.cancel()
         sleepTimerJob?.cancel()
         pauseTimeoutJob?.cancel()
-        playerState.clear()
+        playerState.deactivate()
         audiobookCache.clear() // Clear cache to avoid stale data after re-login
         abandonAudioFocus()
         unregisterNoisyReceiver()
@@ -1720,7 +1720,7 @@ class AudioPlaybackService : MediaLibraryService() {
         abandonAudioFocus()
         unregisterNoisyReceiver()
         unregisterNotificationActionReceiver()
-        playerState.clear()
+        playerState.deactivate()
         super.onDestroy()
     }
 }

--- a/app/src/main/java/com/sappho/audiobooks/service/PlayerState.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/PlayerState.kt
@@ -71,6 +71,19 @@ class PlayerState @Inject constructor() {
         _bufferedPosition.value = position
     }
 
+    /**
+     * Mark playback as inactive while preserving position, duration, and audiobook
+     * for UI display. Called when the service times out or is destroyed — the player
+     * screen may still be visible and needs to show the last known state.
+     */
+    fun deactivate() {
+        _isPlaying.value = false
+        _isLoading.value = false
+        _sleepTimerRemaining.value = null
+        _bufferedPosition.value = 0L
+        _lastActiveTimestamp.value = 0L
+    }
+
     fun clear() {
         _currentAudiobook.value = null
         _isPlaying.value = false


### PR DESCRIPTION
## Summary
- When the playback service dies after 30-min pause timeout, `playerState.clear()` was resetting position and duration to 0, making the player screen show `0:00 / 0:00` — looks like the book would restart from the beginning
- Added `deactivate()` method to PlayerState that only resets active playback fields (isPlaying, isLoading, sleepTimer) while preserving position, duration, and audiobook for UI display
- `checkForUpdatedProgress()` now also restores duration from audiobook metadata and stamps `lastActiveTimestamp` after server reconciliation to avoid redundant fetches on play

## Test plan
- [ ] Listen to an audiobook, pause via lock screen, wait for service timeout (or force-stop the app), reopen — player should show correct position and duration, not 0:00/0:00
- [ ] Listen on another device after phone pause, return to phone — player should show server-synced position
- [ ] Tap play after stale resume — should start from correct position, not beginning

🤖 Generated with [Claude Code](https://claude.com/claude-code)