### PR TITLE
Keep playback notification alive for 30 min after pause

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 62
-        versionName = "0.9.44"
+        versionCode = 63
+        versionName = "0.9.45"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- When the user swipes the app from recents while paused, `MediaLibraryService.onTaskRemoved()` default behavior stops the service immediately
- Now we skip `super.onTaskRemoved()` while the 30-minute pause timeout is still active, keeping the notification alive so users can resume playback
- Also reports accurate play state ("playing" vs "stopped") in progress sync during task removal

## Test plan
- [ ] Play an audiobook, pause it, swipe the app from recents
- [ ] Notification should remain visible for ~30 minutes
- [ ] Tapping play on the notification should resume playback
- [ ] After 30 minutes idle, the notification should dismiss and service stops
- [ ] Swiping away while actively playing should keep playback going

🤖 Generated with [Claude Code](https://claude.com/claude-code)