### PR TITLE
Override Media3 foreground timeout to keep notification for 30 min

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 63
-        versionName = "0.9.45"
+        versionCode = 64
+        versionName = "0.9.46"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
@@ -1663,6 +1663,21 @@ class AudioPlaybackService : MediaLibraryService() {
         stopSelf()
     }
 
+    override fun onUpdateNotification(session: MediaSession, startInForegroundRequired: Boolean) {
+        if (startInForegroundRequired) {
+            // Media3 says we need foreground — do the default
+            super.onUpdateNotification(session, startInForegroundRequired)
+        } else if (pauseTimeoutJob?.isActive == true) {
+            // Media3 wants to demote us out of foreground, but our pause timeout
+            // hasn't expired yet — re-assert foreground with our own notification
+            // so the user can resume from the notification shade.
+            startForeground(NOTIFICATION_ID, createNotification())
+        } else {
+            // Timeout expired or no active playback — let Media3 handle it
+            super.onUpdateNotification(session, startInForegroundRequired)
+        }
+    }
+
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? {
         // Allow any app to connect to the media session for Android Auto compatibility
         // The MediaLibrarySession.Callback methods handle authorization


### PR DESCRIPTION
## Summary
- PR #208 fixed `onTaskRemoved` but the notification was still disappearing after ~10 minutes
- Root cause: Media3's `MediaSessionService` has an internal 10-minute foreground timeout (`DEFAULT_FOREGROUND_SERVICE_TIMEOUT_MS = 600_000`) that demotes the service out of foreground when paused — our 30-minute coroutine timeout never got a chance to fire
- Fix: Override `onUpdateNotification()` to re-assert foreground status with our own notification when Media3 tries to demote us, as long as our 30-minute pause timeout is still active

## Test plan
- [ ] Play an audiobook, pause it, background the app
- [ ] Notification should stay visible for ~30 minutes (not just ~10)
- [ ] Pressing play on the notification after 15+ minutes should resume
- [ ] After 30 minutes idle, notification should dismiss normally
- [ ] Active playback notification should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)