### PR TITLE
Remove title and author from All Books grid

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 64
-        versionName = "0.9.46"
+        versionCode = 65
+        versionName = "0.9.47"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
@@ -3641,34 +3641,6 @@ fun SelectableBookGridItem(
             }
         }
 
-        Spacer(modifier = Modifier.height(6.dp))
-
-        // Title
-        Text(
-            text = book.title,
-            fontSize = 12.sp,
-            fontWeight = FontWeight.Medium,
-            color = SapphoText,
-            maxLines = 1,
-            lineHeight = 14.sp,
-            modifier = Modifier.basicMarquee(
-                iterations = Int.MAX_VALUE,
-                initialDelayMillis = 2000,
-                velocity = 12.dp
-            )
-        )
-
-        // Author
-        book.author?.let {
-            Text(
-                text = it,
-                fontSize = 10.sp,
-                color = SapphoIconDefault,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove book title and author text from `SelectableBookGridItem` in the library All Books view
- Results in a cleaner, cover-only grid layout
- Version bump to 0.9.47 (65)

## Test plan
- [ ] Open Library → All Books and verify only cover images are shown (no title/author text below)
- [ ] Verify progress bars, rating badges, and selection mode still work correctly
- [ ] Verify series position badges still appear when sorted by series

🤖 Generated with [Claude Code](https://claude.com/claude-code)