### PR TITLE
Fix player resume and chapter-scoped seek bar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 66
-        versionName = "0.9.48"
+        versionCode = 67
+        versionName = "0.9.49"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
@@ -150,13 +150,9 @@ fun PlayerScreen(
         }
     }
 
-    // Load audiobook details if not already loaded
+    // Load audiobook and start playback (restores saved position if startPosition is 0)
     LaunchedEffect(audiobookId) {
-        if (!fromMinimized) {
-            viewModel.loadAndStartPlayback(audiobookId, startPosition)
-        } else {
-            viewModel.loadAudiobookDetails(audiobookId)
-        }
+        viewModel.loadAndStartPlayback(audiobookId, startPosition)
         viewModel.loadChapters(audiobookId)
     }
 
@@ -631,8 +627,21 @@ fun PlayerScreen(
                     var dragPosition by remember { mutableFloatStateOf(0f) }
                     var wasPlayingBeforeDrag by remember { mutableStateOf(false) }
 
+                    // Chapter-aware seek: use chapter boundaries when available
+                    val chapterStart = currentChapter?.startTime?.toFloat() ?: 0f
+                    val chapterEnd = currentChapter?.endTime?.toFloat()
+                        ?: currentChapter?.let { (it.startTime + (it.duration ?: 0.0)).toFloat() }
+                        ?: duration.toFloat()
+                    val hasChapter = currentChapter != null && chapters.size > 1
+                    val seekRangeStart = if (hasChapter) chapterStart else 0f
+                    val seekRangeEnd = if (hasChapter) chapterEnd else duration.toFloat()
+
                     // The displayed position: use drag position while dragging, actual position otherwise
                     val displayedPosition = if (isDragging) dragPosition else currentPosition.toFloat()
+
+                    // Chapter-relative times for display
+                    val displayPos = displayedPosition - seekRangeStart
+                    val displayDur = seekRangeEnd - seekRangeStart
 
                     Column(modifier = Modifier.fillMaxWidth()) {
                         // Time popup while dragging
@@ -651,7 +660,7 @@ fun PlayerScreen(
                                         .padding(horizontal = 16.dp, vertical = 8.dp)
                                 ) {
                                     Text(
-                                        text = formatTime(dragPosition.toLong()),
+                                        text = formatTime(displayPos.toLong().coerceAtLeast(0)),
                                         style = MaterialTheme.typography.titleLarge,
                                         color = SapphoInfo
                                     )
@@ -664,19 +673,19 @@ fun PlayerScreen(
                             horizontalArrangement = Arrangement.SpaceBetween
                         ) {
                             Text(
-                                text = formatTime(displayedPosition.toLong()),
+                                text = formatTime(displayPos.toLong().coerceAtLeast(0)),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = if (isDragging) SapphoInfo else SapphoIconDefault
                             )
                             Text(
-                                text = formatTime(duration),
+                                text = formatTime(displayDur.toLong().coerceAtLeast(0)),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = SapphoIconDefault
                             )
                         }
 
                         Slider(
-                            value = if (duration > 0) displayedPosition else 0f,
+                            value = if (seekRangeEnd > seekRangeStart) displayedPosition.coerceIn(seekRangeStart, seekRangeEnd) else 0f,
                             onValueChange = { newValue ->
                                 if (!isDragging) {
                                     // Capture playing state when drag starts
@@ -686,7 +695,7 @@ fun PlayerScreen(
                                 dragPosition = newValue
                             },
                             onValueChangeFinished = {
-                                // Seek to position, only resume playback if it was playing before
+                                // Seek to absolute position, only resume playback if it was playing before
                                 if (wasPlayingBeforeDrag) {
                                     AudioPlaybackService.instance?.seekToAndPlay(dragPosition.toLong())
                                 } else {
@@ -694,7 +703,7 @@ fun PlayerScreen(
                                 }
                                 isDragging = false
                             },
-                            valueRange = 0f..duration.toFloat().coerceAtLeast(1f),
+                            valueRange = seekRangeStart..seekRangeEnd.coerceAtLeast(seekRangeStart + 1f),
                             thumb = {
                                 Box(
                                     modifier = Modifier


### PR DESCRIPTION
## Summary
- **Fix: Minimized player bar not resuming position** — Tapping the player bar after app restart now properly restores saved progress from the server, instead of starting from position 0
- **Fix: Seek bar showing full book length** — When playing within a chapter, the seek bar now shows chapter-relative position and duration instead of the full audiobook length

## Test plan
- [ ] Listen to a book, close app, reopen next day → tap minimized player bar → should resume from saved position
- [ ] Play a book with chapters → seek bar should show current chapter duration, not full book duration
- [ ] Drag seek bar within chapter boundaries → should seek correctly within the chapter
- [ ] When chapter changes, seek bar range should update to new chapter
- [ ] Books without chapters should still show full book duration on seek bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)