### PR TITLE
Remove delete from download button on detail page

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 68
-        versionName = "0.9.50"
+        versionCode = 69
+        versionName = "0.9.51"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
@@ -113,7 +113,6 @@ fun AudiobookDetailScreen(
     val fetchChaptersResult by viewModel.fetchChaptersResult.collectAsState()
     val isDeletingFile by viewModel.isDeletingFile.collectAsState()
     val deleteFileError by viewModel.deleteFileError.collectAsState()
-    var showDeleteDownloadDialog by remember { mutableStateOf(false) }
     var showChaptersDialog by remember { mutableStateOf(false) }
     var fileToDelete by remember { mutableStateOf<com.sappho.audiobooks.domain.model.DirectoryFile?>(null) }
     var showEditMetadataDialog by remember { mutableStateOf(false) }
@@ -683,8 +682,7 @@ fun AudiobookDetailScreen(
                                             DownloadService.cancelDownload(context)
                                         }
                                         isDownloaded -> {
-                                            downloadCancelHaptic()
-                                            if (!isOffline) showDeleteDownloadDialog = true
+                                            // No-op: deletion only available from Downloads screen
                                         }
                                         hasDownloadError -> {
                                             downloadStartHaptic()
@@ -1558,35 +1556,6 @@ fun AudiobookDetailScreen(
             )
         }
 
-        // Delete Download Confirmation Dialog
-        if (showDeleteDownloadDialog) {
-            AlertDialog(
-                onDismissRequest = { showDeleteDownloadDialog = false },
-                title = { Text("Remove Download", color = Color.White) },
-                text = {
-                    Text(
-                        "Remove this book from downloads? This will only delete the local file - your listening progress on the server will not be affected.",
-                        color = SapphoTextLight
-                    )
-                },
-                confirmButton = {
-                    TextButton(
-                        onClick = {
-                            viewModel.deleteDownload()
-                            showDeleteDownloadDialog = false
-                        }
-                    ) {
-                        Text("Remove", color = SapphoError)
-                    }
-                },
-                dismissButton = {
-                    TextButton(onClick = { showDeleteDownloadDialog = false }) {
-                        Text("Cancel", color = SapphoInfo)
-                    }
-                },
-                containerColor = SapphoSurfaceLight
-            )
-        }
 
         // AI Recap Dialog (Catch Up)
         if (showRecapDialog) {


### PR DESCRIPTION
## Summary
- Download button on detail page no longer allows deleting downloads
- Once downloaded, tapping the button is a no-op (shows green checkmark only)
- Deletion is only available from the Downloads screen in the dropdown menu
- Removed unused delete confirmation dialog and state variable
- Version bump to 0.9.51 (69)

## Test plan
- [ ] Tap download button to start a download
- [ ] Verify downloaded state shows green checkmark
- [ ] Verify tapping checkmark does nothing (no delete dialog)
- [ ] Verify deletion still works from Downloads screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)