### PR TITLE
Fix play button colors to match mini/full player

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 69
-        versionName = "0.9.51"
+        versionCode = 70
+        versionName = "0.9.52"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
@@ -635,8 +635,8 @@ fun AudiobookDetailScreen(
                                 .weight(1f)
                                 .height(56.dp),
                             colors = ButtonDefaults.buttonColors(
-                                containerColor = if (isThisBookPlaying) SapphoInfo.copy(alpha = 0.15f) else SapphoSuccess.copy(alpha = 0.15f),
-                                contentColor = if (isThisBookPlaying) LegacyBluePale else LegacyGreenPale,
+                                containerColor = if (isThisBookPlaying) SapphoSuccess.copy(alpha = 0.15f) else SapphoInfo.copy(alpha = 0.15f),
+                                contentColor = if (isThisBookPlaying) LegacyGreenPale else LegacyBluePale,
                                 disabledContainerColor = SapphoSurface,
                                 disabledContentColor = SapphoTextSecondary
                             ),

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
@@ -529,7 +529,7 @@ fun PlayerScreen(
                                 .size(72.dp)
                                 .scale(playScale)
                                 .clip(CircleShape)
-                                .background(SapphoInfo)
+                                .background(if (isPlaying) SapphoSuccess else SapphoInfo)
                                 .clickable(
                                     interactionSource = playSource,
                                     indication = null


### PR DESCRIPTION
## Summary
- Detail page play button: green when playing, blue when paused (was inverted)
- Full player play button: green when playing, blue when paused (was always blue)
- Now consistent with mini player behavior across all three views
- Version bump to 0.9.52 (70)

## Test plan
- [ ] Start playing a book from detail page — button should turn green
- [ ] Pause from detail page — button should turn blue
- [ ] Verify mini player button matches (green=playing, blue=paused)
- [ ] Verify full player button matches (green=playing, blue=paused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)