### PR TITLE
Move download/overflow buttons to left of play button

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 70
-        versionName = "0.9.52"
+        versionCode = 71
+        versionName = "0.9.53"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
@@ -610,66 +610,6 @@ fun AudiobookDetailScreen(
                         horizontalArrangement = Arrangement.spacedBy(12.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        // Play button
-                        Button(
-                            onClick = {
-                                if (!canPlay) return@Button
-                                playButtonHaptic()
-                                val service = AudioPlaybackService.instance
-                                if (isThisBookLoaded && service != null) {
-                                    // Book is already loaded and service is alive, try to toggle play/pause
-                                    val playerHandled = service.togglePlayPause()
-                                    if (!playerHandled) {
-                                        // Player was null (service exists but player released)
-                                        // Restart playback from current position or saved progress
-                                        val position = if (currentPosition > 0) currentPosition.toInt() else progress?.position
-                                        onPlayClick(book.id, position)
-                                    }
-                                } else {
-                                    // Start playing a new book (or restart if service was killed)
-                                    onPlayClick(book.id, progress?.position)
-                                }
-                            },
-                            enabled = canPlay,
-                            modifier = Modifier
-                                .weight(1f)
-                                .height(56.dp),
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = if (isThisBookPlaying) SapphoSuccess.copy(alpha = 0.15f) else SapphoInfo.copy(alpha = 0.15f),
-                                contentColor = if (isThisBookPlaying) LegacyGreenPale else LegacyBluePale,
-                                disabledContainerColor = SapphoSurface,
-                                disabledContentColor = SapphoTextSecondary
-                            ),
-                            shape = RoundedCornerShape(12.dp),
-                            border = BorderStroke(1.dp, Color.White.copy(alpha = if (canPlay) 0.1f else 0.05f))
-                        ) {
-                            if (isProgressLoading && !isThisBookLoaded) {
-                                CircularProgressIndicator(
-                                    modifier = Modifier.size(20.dp),
-                                    color = SapphoTextSecondary,
-                                    strokeWidth = 2.dp
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(
-                                    text = "Loading...",
-                                    fontSize = 16.sp,
-                                    fontWeight = FontWeight.SemiBold
-                                )
-                            } else {
-                                Icon(
-                                    imageVector = if (isThisBookPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(24.dp)
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(
-                                    text = if (isThisBookPlaying) "Pause" else if (progress?.position ?: 0 > 0) "Continue" else "Play",
-                                    fontSize = 16.sp,
-                                    fontWeight = FontWeight.SemiBold
-                                )
-                            }
-                        }
-
                         // Download button (icon only)
                         if (showDownloadButton) {
                             val downloadStartHaptic = HapticPatterns.downloadStart()
@@ -933,6 +873,62 @@ fun AudiobookDetailScreen(
                                         )
                                     }
                                 }
+                            }
+                        }
+
+                        // Play button (expands to fill remaining space)
+                        Button(
+                            onClick = {
+                                if (!canPlay) return@Button
+                                playButtonHaptic()
+                                val service = AudioPlaybackService.instance
+                                if (isThisBookLoaded && service != null) {
+                                    val playerHandled = service.togglePlayPause()
+                                    if (!playerHandled) {
+                                        val position = if (currentPosition > 0) currentPosition.toInt() else progress?.position
+                                        onPlayClick(book.id, position)
+                                    }
+                                } else {
+                                    onPlayClick(book.id, progress?.position)
+                                }
+                            },
+                            enabled = canPlay,
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(56.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = if (isThisBookPlaying) SapphoSuccess.copy(alpha = 0.15f) else SapphoInfo.copy(alpha = 0.15f),
+                                contentColor = if (isThisBookPlaying) LegacyGreenPale else LegacyBluePale,
+                                disabledContainerColor = SapphoSurface,
+                                disabledContentColor = SapphoTextSecondary
+                            ),
+                            shape = RoundedCornerShape(12.dp),
+                            border = BorderStroke(1.dp, Color.White.copy(alpha = if (canPlay) 0.1f else 0.05f))
+                        ) {
+                            if (isProgressLoading && !isThisBookLoaded) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(20.dp),
+                                    color = SapphoTextSecondary,
+                                    strokeWidth = 2.dp
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = "Loading...",
+                                    fontSize = 16.sp,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = if (isThisBookPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(24.dp)
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = if (isThisBookPlaying) "Pause" else if (progress?.position ?: 0 > 0) "Continue" else "Play",
+                                    fontSize = 16.sp,
+                                    fontWeight = FontWeight.SemiBold
+                                )
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Reorder detail page action row: download + overflow on the left, play button on the right
- Matches the iOS layout for consistency across platforms
- Version bump to 0.9.53 (71)

## Test plan
- [ ] Verify download button appears on the left
- [ ] Verify overflow menu button appears in the middle
- [ ] Verify play button fills remaining space on the right

🤖 Generated with [Claude Code](https://claude.com/claude-code)