### PR TITLE
Add animated progress bar and chapter mode default

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/data/repository/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/repository/UserPreferencesRepository.kt
@@ -202,7 +202,7 @@ class UserPreferencesRepository @Inject constructor(
         const val DEFAULT_REWIND_ON_RESUME = 0
         const val DEFAULT_SLEEP_TIMER = 0
         const val DEFAULT_BUFFER_SIZE = 60  // 1 minute default
-        const val DEFAULT_SHOW_CHAPTER_PROGRESS = false
+        const val DEFAULT_SHOW_CHAPTER_PROGRESS = true
 
         // Available options for skip intervals
         val SKIP_FORWARD_OPTIONS = listOf(10, 15, 30, 45, 60, 90)

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
@@ -10,6 +10,9 @@ import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
@@ -675,6 +678,27 @@ fun PlayerScreen(
                             )
                         }
 
+                        // Animated gradient for progress fill
+                        val progressTransition = rememberInfiniteTransition(label = "progress")
+                        val progressGradientPhase by progressTransition.animateFloat(
+                            initialValue = 0f,
+                            targetValue = 1f,
+                            animationSpec = infiniteRepeatable(
+                                animation = tween(2000, easing = LinearEasing),
+                                repeatMode = RepeatMode.Restart
+                            ),
+                            label = "progressGradient"
+                        )
+                        val thumbGlowAlpha by progressTransition.animateFloat(
+                            initialValue = 0.2f,
+                            targetValue = 0.6f,
+                            animationSpec = infiniteRepeatable(
+                                animation = tween(3000, easing = FastOutSlowInEasing),
+                                repeatMode = RepeatMode.Reverse
+                            ),
+                            label = "thumbGlow"
+                        )
+
                         Slider(
                             value = if (duration > 0) displayedPosition else 0f,
                             onValueChange = { newValue ->
@@ -700,7 +724,17 @@ fun PlayerScreen(
                                     modifier = Modifier
                                         .size(16.dp)
                                         .clip(CircleShape)
-                                        .background(SapphoInfo)
+                                        .background(if (isPlaying) SapphoSuccess else SapphoInfo)
+                                        .then(
+                                            if (isPlaying) {
+                                                Modifier.drawBehind {
+                                                    drawCircle(
+                                                        color = SapphoSuccess.copy(alpha = thumbGlowAlpha),
+                                                        radius = size.maxDimension / 1.2f
+                                                    )
+                                                }
+                                            } else Modifier
+                                        )
                                 )
                             },
                             track = { sliderState ->
@@ -720,7 +754,19 @@ fun PlayerScreen(
                                             .fillMaxWidth(fraction)
                                             .height(4.dp)
                                             .clip(RoundedCornerShape(2.dp))
-                                            .background(SapphoInfo)
+                                            .background(
+                                                if (isPlaying) {
+                                                    Brush.horizontalGradient(
+                                                        colors = listOf(SapphoInfo, SapphoSuccess, SapphoInfo),
+                                                        startX = -200f + progressGradientPhase * 800f,
+                                                        endX = 200f + progressGradientPhase * 800f
+                                                    )
+                                                } else {
+                                                    Brush.horizontalGradient(
+                                                        colors = listOf(SapphoInfo, SapphoInfo)
+                                                    )
+                                                }
+                                            )
                                     )
                                 }
                             }


### PR DESCRIPTION
## Summary
- Animated gradient shimmer (blue-green) on full player progress bar when playing
- Glowing green thumb with pulsing shadow when playing
- Chapter progress mode now defaults to on

## Test plan
- [ ] Play an audiobook, verify progress bar has animated gradient
- [ ] Verify thumb glows green while playing
- [ ] Fresh install defaults to chapter progress mode
- [ ] Paused state shows static blue bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)