### PR TITLE
Fix collection creation missing is_public field

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 76
-        versionName = "0.9.58"
+        versionCode = 77
+        versionName = "0.9.59"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
@@ -1029,7 +1029,9 @@ data class CollectionDetail(
 
 data class CreateCollectionRequest(
     val name: String,
-    val description: String? = null
+    val description: String? = null,
+    @com.google.gson.annotations.SerializedName("is_public")
+    val isPublic: Boolean = false
 )
 
 data class UpdateCollectionRequest(

--- a/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionsScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionsScreen.kt
@@ -287,8 +287,8 @@ fun CollectionsScreen(
             CreateCollectionDialog(
                 isCreating = isCreating,
                 onDismiss = { showCreateDialog = false },
-                onCreate = { name, description ->
-                    viewModel.createCollection(name, description) { success, _ ->
+                onCreate = { name, description, isPublic ->
+                    viewModel.createCollection(name, description, isPublic) { success, _ ->
                         if (success) {
                             showCreateDialog = false
                         }
@@ -648,10 +648,11 @@ private fun SkeletonCollectionGrid() {
 private fun CreateCollectionDialog(
     isCreating: Boolean,
     onDismiss: () -> Unit,
-    onCreate: (String, String?) -> Unit
+    onCreate: (String, String?, Boolean) -> Unit
 ) {
     var name by remember { mutableStateOf("") }
     var description by remember { mutableStateOf("") }
+    var isPublic by remember { mutableStateOf(false) }
 
     Dialog(onDismissRequest = onDismiss) {
         Card(
@@ -710,6 +711,37 @@ private fun CreateCollectionDialog(
                     maxLines = 3
                 )
 
+                Spacer(modifier = Modifier.height(Spacing.M))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column {
+                        Text(
+                            text = "Public Collection",
+                            color = SapphoText,
+                            fontSize = 14.sp
+                        )
+                        Text(
+                            text = "Visible to all users",
+                            color = SapphoIconDefault,
+                            fontSize = 12.sp
+                        )
+                    }
+                    Switch(
+                        checked = isPublic,
+                        onCheckedChange = { isPublic = it },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = Color.White,
+                            checkedTrackColor = SapphoInfo,
+                            uncheckedThumbColor = SapphoIconDefault,
+                            uncheckedTrackColor = SapphoProgressTrack
+                        )
+                    )
+                }
+
                 Spacer(modifier = Modifier.height(Spacing.L))
 
                 Row(
@@ -721,7 +753,7 @@ private fun CreateCollectionDialog(
                     }
                     Spacer(modifier = Modifier.width(Spacing.XS))
                     Button(
-                        onClick = { onCreate(name, description.ifBlank { null }) },
+                        onClick = { onCreate(name, description.ifBlank { null }, isPublic) },
                         enabled = name.isNotBlank() && !isCreating,
                         colors = ButtonDefaults.buttonColors(
                             containerColor = SapphoInfo

--- a/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionsViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionsViewModel.kt
@@ -57,11 +57,11 @@ class CollectionsViewModel @Inject constructor(
         }
     }
 
-    fun createCollection(name: String, description: String?, onResult: (Boolean, String) -> Unit) {
+    fun createCollection(name: String, description: String?, isPublic: Boolean = false, onResult: (Boolean, String) -> Unit) {
         viewModelScope.launch {
             _isCreating.value = true
             try {
-                val response = api.createCollection(CreateCollectionRequest(name, description))
+                val response = api.createCollection(CreateCollectionRequest(name, description, isPublic))
                 if (response.isSuccessful) {
                     loadCollections()
                     onResult(true, "Collection created")

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AddToCollectionDialog.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AddToCollectionDialog.kt
@@ -32,10 +32,11 @@ internal fun AddToCollectionDialog(
     isLoading: Boolean,
     onDismiss: () -> Unit,
     onToggleCollection: (Int) -> Unit,
-    onCreateCollection: (String) -> Unit
+    onCreateCollection: (String, Boolean) -> Unit
 ) {
     var showCreateForm by remember { mutableStateOf(false) }
     var newCollectionName by remember { mutableStateOf("") }
+    var newCollectionIsPublic by remember { mutableStateOf(false) }
 
     Dialog(onDismissRequest = onDismiss) {
         Card(
@@ -91,15 +92,19 @@ internal fun AddToCollectionDialog(
                     if (showCreateForm) {
                         CreateCollectionForm(
                             name = newCollectionName,
+                            isPublic = newCollectionIsPublic,
                             onNameChange = { newCollectionName = it },
+                            onIsPublicChange = { newCollectionIsPublic = it },
                             onCancel = {
                                 showCreateForm = false
                                 newCollectionName = ""
+                                newCollectionIsPublic = false
                             },
                             onCreate = {
                                 if (newCollectionName.isNotBlank()) {
-                                    onCreateCollection(newCollectionName.trim())
+                                    onCreateCollection(newCollectionName.trim(), newCollectionIsPublic)
                                     newCollectionName = ""
+                                    newCollectionIsPublic = false
                                     showCreateForm = false
                                 }
                             }
@@ -171,7 +176,9 @@ internal fun AddToCollectionDialog(
 @Composable
 private fun CreateCollectionForm(
     name: String,
+    isPublic: Boolean,
     onNameChange: (String) -> Unit,
+    onIsPublicChange: (Boolean) -> Unit,
     onCancel: () -> Unit,
     onCreate: () -> Unit
 ) {
@@ -190,6 +197,28 @@ private fun CreateCollectionForm(
             ),
             singleLine = true
         )
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = "Public",
+                color = SapphoIconDefault,
+                fontSize = 14.sp
+            )
+            Switch(
+                checked = isPublic,
+                onCheckedChange = onIsPublicChange,
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = Color.White,
+                    checkedTrackColor = SapphoInfo,
+                    uncheckedThumbColor = SapphoIconDefault,
+                    uncheckedTrackColor = SapphoProgressTrack
+                )
+            )
+        }
         Spacer(modifier = Modifier.height(8.dp))
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
@@ -1803,8 +1803,8 @@ fun AudiobookDetailScreen(
                     onToggleCollection = { collectionId ->
                         viewModel.toggleBookInCollection(collectionId, book.id)
                     },
-                    onCreateCollection = { name ->
-                        viewModel.createCollectionAndAddBook(name, book.id)
+                    onCreateCollection = { name, isPublic ->
+                        viewModel.createCollectionAndAddBook(name, book.id, isPublic)
                     }
                 )
             }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModel.kt
@@ -860,10 +860,10 @@ class AudiobookDetailViewModel @Inject constructor(
         }
     }
 
-    fun createCollectionAndAddBook(name: String, bookId: Int) {
+    fun createCollectionAndAddBook(name: String, bookId: Int, isPublic: Boolean = false) {
         viewModelScope.launch {
             try {
-                val createResponse = api.createCollection(CreateCollectionRequest(name, null))
+                val createResponse = api.createCollection(CreateCollectionRequest(name, null, isPublic))
                 if (createResponse.isSuccessful) {
                     val newCollection = createResponse.body()
                     if (newCollection != null) {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
@@ -355,8 +355,8 @@ fun HomeScreen(
             onToggleCollection = { collectionId ->
                 viewModel.toggleBookInCollection(collectionId, selectedBookId)
             },
-            onCreateCollection = { name ->
-                viewModel.createCollectionAndAddBook(name, selectedBookId)
+            onCreateCollection = { name, isPublic ->
+                viewModel.createCollectionAndAddBook(name, selectedBookId, isPublic)
             }
         )
     }
@@ -726,10 +726,11 @@ private fun AddToCollectionDialog(
     isLoading: Boolean,
     onDismiss: () -> Unit,
     onToggleCollection: (Int) -> Unit,
-    onCreateCollection: (String) -> Unit
+    onCreateCollection: (String, Boolean) -> Unit
 ) {
     var showCreateForm by remember { mutableStateOf(false) }
     var newCollectionName by remember { mutableStateOf("") }
+    var newCollectionIsPublic by remember { mutableStateOf(false) }
 
     Dialog(onDismissRequest = onDismiss) {
         Card(
@@ -801,11 +802,34 @@ private fun AddToCollectionDialog(
                             Spacer(modifier = Modifier.height(8.dp))
                             Row(
                                 modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(
+                                    text = "Public",
+                                    color = SapphoIconDefault,
+                                    fontSize = 14.sp
+                                )
+                                Switch(
+                                    checked = newCollectionIsPublic,
+                                    onCheckedChange = { newCollectionIsPublic = it },
+                                    colors = SwitchDefaults.colors(
+                                        checkedThumbColor = Color.White,
+                                        checkedTrackColor = SapphoInfo,
+                                        uncheckedThumbColor = SapphoIconDefault,
+                                        uncheckedTrackColor = SapphoProgressTrack
+                                    )
+                                )
+                            }
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
                                 horizontalArrangement = Arrangement.End
                             ) {
                                 TextButton(onClick = {
                                     showCreateForm = false
                                     newCollectionName = ""
+                                    newCollectionIsPublic = false
                                 }) {
                                     Text("Cancel", color = SapphoIconDefault)
                                 }
@@ -813,8 +837,9 @@ private fun AddToCollectionDialog(
                                 Button(
                                     onClick = {
                                         if (newCollectionName.isNotBlank()) {
-                                            onCreateCollection(newCollectionName.trim())
+                                            onCreateCollection(newCollectionName.trim(), newCollectionIsPublic)
                                             newCollectionName = ""
+                                            newCollectionIsPublic = false
                                             showCreateForm = false
                                         }
                                     },
@@ -825,8 +850,8 @@ private fun AddToCollectionDialog(
                                     shape = RoundedCornerShape(8.dp)
                                 ) {
                                     Text("Create & Add")
-    }
-}
+                                }
+                            }
                         }
                     } else {
                         Button(
@@ -889,10 +914,8 @@ private fun AddToCollectionDialog(
                                             contentDescription = "In collection",
                                             tint = SapphoInfo
                                         )
-    }
-}
-
-
+                                    }
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeViewModel.kt
@@ -299,10 +299,10 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun createCollectionAndAddBook(name: String, bookId: Int) {
+    fun createCollectionAndAddBook(name: String, bookId: Int, isPublic: Boolean = false) {
         viewModelScope.launch {
             try {
-                val createResponse = api.createCollection(CreateCollectionRequest(name, null))
+                val createResponse = api.createCollection(CreateCollectionRequest(name, null, isPublic))
                 if (createResponse.isSuccessful) {
                     val newCollection = createResponse.body()
                     if (newCollection != null) {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryViewModel.kt
@@ -238,10 +238,10 @@ class LibraryViewModel @Inject constructor(
         _selectedCollection.value = null
     }
 
-    fun createCollection(name: String, description: String?, onResult: (Boolean, String) -> Unit) {
+    fun createCollection(name: String, description: String?, isPublic: Boolean = false, onResult: (Boolean, String) -> Unit) {
         viewModelScope.launch {
             try {
-                val response = api.createCollection(CreateCollectionRequest(name, description))
+                val response = api.createCollection(CreateCollectionRequest(name, description, isPublic))
                 if (response.isSuccessful) {
                     loadCollections()
                     onResult(true, "Collection created")


### PR DESCRIPTION
## Summary
- `CreateCollectionRequest` was missing the `is_public` field, causing all collections created from Android to default to private
- This was the root cause of missing collection notifications — collections were created private, items added while private (no notification), then toggled public later
- Added public/private toggle to `CreateCollectionDialog` (collections page) and inline `AddToCollectionDialog` (home/detail quick-add)

## Test plan
- [ ] Create a new collection from Collections page with "Public" toggle ON — verify it appears as public
- [ ] Create a new collection from "Add to Collection" dialog with "Public" toggle ON — verify it's public
- [ ] Add a book to a public collection as another user — verify notification is generated
- [ ] Create collection with toggle OFF — verify it's private

🤖 Generated with [Claude Code](https://claude.com/claude-code)