### PR TITLE
Change chapter button to static Chapters label

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 78
-        versionName = "0.9.60"
+        versionCode = 79
+        versionName = "0.9.61"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
@@ -805,12 +805,11 @@ fun PlayerScreen(
                                     tint = LegacyBlueLight
                                 )
                                 Spacer(modifier = Modifier.height(6.dp))
-                                MarqueeText(
-                                    text = currentChapter?.title ?: "—",
+                                Text(
+                                    text = "Chapters",
                                     fontSize = 12.sp,
                                     fontWeight = FontWeight.Medium,
-                                    color = Color.White,
-                                    modifier = Modifier.fillMaxWidth()
+                                    color = Color.White
                                 )
                             }
                         }


### PR DESCRIPTION
## Summary
- Replace MarqueeText chapter title with static "Chapters" label on player button
- Chapter title is already shown elsewhere, no need to duplicate it
- Bump version to 79 (0.9.61)

## Test plan
- [ ] Verify chapter button shows "Chapters" in maximized player

🤖 Generated with [Claude Code](https://claude.com/claude-code)