### PR TITLE
Show current chapter title in maximized player

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 79
-        versionName = "0.9.61"
+        versionCode = 80
+        versionName = "0.9.62"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
@@ -458,6 +458,19 @@ fun PlayerScreen(
                         )
                     }
 
+                    // Current chapter title
+                    currentChapter?.title?.let { chapterTitle ->
+                        Spacer(modifier = Modifier.height(2.dp))
+                        Text(
+                            text = chapterTitle,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = LegacyBlueLight,
+                            textAlign = TextAlign.Center,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+
                     Spacer(modifier = Modifier.height(32.dp))
 
                     // Main playback controls with animations


### PR DESCRIPTION
## Summary
- Display current chapter title below series info in maximized player
- Matches iOS player layout
- Bump version to 80 (0.9.62)

## Test plan
- [ ] Verify chapter title appears below series in maximized player
- [ ] Verify it updates when chapter changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)