### PR TITLE
Harden cast auth token handling and cleartext traffic config

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Sappho"
-        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="31">
 
         <!-- Cast Options Provider -->

--- a/app/src/main/java/com/sappho/audiobooks/cast/CastHelper.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/CastHelper.kt
@@ -475,7 +475,11 @@ class CastHelper @Inject constructor(
             // Register callback to listen for Cast state changes
             remoteMediaClient.registerCallback(remoteMediaClientCallback)
 
-            // Add access token to stream URL for Cast receiver authentication
+            // SECURITY NOTE: Auth token must be passed as a URL query parameter because
+            // the Chromecast receiver app fetches the media URL directly. The Cast SDK does
+            // not support injecting custom HTTP headers into the receiver's media requests.
+            // This is an inherent limitation of the Google Cast protocol, not a design choice.
+            // See: https://developers.google.com/cast/docs/reference/web_receiver
             val token = authRepository.getTokenSync()
             val authenticatedStreamUrl = if (token != null) {
                 "$streamUrl?token=$token"

--- a/app/src/main/java/com/sappho/audiobooks/cast/CastManager.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/CastManager.kt
@@ -279,7 +279,14 @@ class CastManager @Inject constructor(
             return
         }
 
-        // For other protocols, append auth token to URL
+        // SECURITY NOTE: Auth token must be passed as a URL query parameter because all
+        // cast protocols (AirPlay, Kodi JSON-RPC, Roku ECP) work by instructing a remote
+        // device to fetch a URL. The remote device's HTTP client cannot be configured with
+        // custom headers from the sender app. This is an inherent limitation of these
+        // protocols, not a design choice. The risk is mitigated by:
+        //   1. Cast targets are local network devices (not internet-facing)
+        //   2. The Sappho server should treat token query params as equivalent to headers
+        //   3. Stream URLs are ephemeral and not persisted by cast receivers
         val token = authRepository.getTokenSync()
         val authenticatedUrl = if (token != null) "$streamUrl?token=$token" else streamUrl
         val authenticatedCoverUrl = if (coverUrl != null && token != null) {
@@ -289,7 +296,7 @@ class CastManager @Inject constructor(
         }
 
         Log.d(TAG, "castAudiobook: Sending to $protocol target, " +
-                "hasToken=${token != null}, urlLength=${authenticatedUrl.length}")
+                "hasToken=${token != null}")
 
         target.loadMedia(
             streamUrl = authenticatedUrl,

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Network security configuration for Sappho.
+
+    IMPORTANT: Cleartext (HTTP) traffic must remain permitted globally because:
+
+    1. Self-hosted Sappho servers on local networks use HTTP with raw IP addresses
+       (e.g., http://192.168.1.100:3002). Android's domain-config does NOT support
+       CIDR notation or IP address ranges — it only matches exact hostnames. Setting
+       base-config to cleartextTrafficPermitted="false" would break all IP-based
+       server connections.
+
+    2. Cast protocols (Kodi JSON-RPC on port 8080, AirPlay on port 7000, Roku ECP
+       on port 8060) communicate over HTTP to local network devices. These protocols
+       do not support TLS.
+
+    3. The server URL is user-configured at login time, so we cannot predict or
+       enumerate all possible local network addresses at build time.
+
+    MITIGATION: The OkHttpClient interceptor in NetworkModule.kt handles
+    authentication via Authorization headers (not cleartext credentials in URLs)
+    for all API requests. Only cast media URLs use query parameter tokens, which
+    is documented as a protocol limitation in CastManager.kt and CastHelper.kt.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
## Summary

Addresses two security audit items:

- **#228 — Auth token in cast URL query parameters**: All four cast protocols (Chromecast, AirPlay, Kodi JSON-RPC, Roku ECP) require passing auth tokens in URL query parameters because they instruct a remote device to fetch a media URL directly. The remote device's HTTP client cannot be configured with custom headers from the sender app. This is an inherent protocol limitation. Added detailed security comments to both `CastManager.kt` and `CastHelper.kt` documenting this constraint and the mitigating factors. Also removed `urlLength` from the cast debug log to avoid leaking token-related metadata.

- **#229 — Cleartext traffic configuration**: Replaced the blanket `android:usesCleartextTraffic="true"` in `AndroidManifest.xml` with an explicit `android:networkSecurityConfig` referencing a new `network_security_config.xml`. The config documents why cleartext must remain globally permitted: Android's `domain-config` does not support CIDR notation or IP address ranges, so setting `base-config cleartextTrafficPermitted="false"` would break all IP-based self-hosted server connections (e.g., `http://192.168.1.100:3002`) and cast device communication.

## Test plan

- [ ] Verify casting to Chromecast still works with authenticated media URLs
- [ ] Verify connecting to a self-hosted server via HTTP IP address still works
- [ ] Verify connecting to a self-hosted server via HTTPS domain still works
- [ ] Verify cast device discovery still works (Kodi, AirPlay)
- [ ] Verify debug logs no longer contain `urlLength` for cast URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)