### PR TITLE
Add @Volatile to AudioPlaybackService static instance for thread safety

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
@@ -125,6 +125,7 @@ class AudioPlaybackService : MediaLibraryService() {
         const val ACTION_SKIP_BACKWARD = "com.sappho.audiobooks.SKIP_BACKWARD"
         const val ACTION_PLAY_PAUSE = "com.sappho.audiobooks.PLAY_PAUSE"
 
+        @Volatile
         var instance: AudioPlaybackService? = null
             private set
     }


### PR DESCRIPTION
## Summary
- Adds `@Volatile` annotation to the `AudioPlaybackService.instance` companion object field to ensure cross-thread visibility
- Without `@Volatile`, background threads (e.g., `PlayerViewModel`'s coroutine polling loop at line 121) could cache a stale `null` value and never observe the instance set by `onCreate()` on the main thread
- This is the minimal, correct fix — JVM reference reads/writes are already atomic, so `@Volatile` provides the needed memory visibility guarantee without synchronization overhead

Fixes #235

## Test plan
- [x] `./gradlew assembleDebug` builds successfully
- [x] `./gradlew test` — all unit tests pass
- [ ] Manual testing: play an audiobook, verify playback controls (play/pause, skip, seek, sleep timer) work correctly
- [ ] Verify minimized player bar still interacts with the service properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)