### PR TITLE
Bump version to 0.9.66 for Play Store deploy

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 82
-        versionName = "0.9.64"
+        versionCode = 84
+        versionName = "0.9.66"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- Bump versionCode 82 → 84, versionName 0.9.64 → 0.9.66
- Fixes Play Store deploy failures from merges without version bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)