### PR TITLE
fix: pre-fill username on login screen after token expiry

### DIFF
--- a/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginScreen.kt
@@ -41,7 +41,7 @@ fun LoginScreen(
     viewModel: LoginViewModel = hiltViewModel(),
     onLoginSuccess: () -> Unit
 ) {
-    var username by remember { mutableStateOf("") }
+    var username by remember { mutableStateOf(viewModel.savedUsername ?: "") }
     var password by remember { mutableStateOf("") }
     var passwordVisible by remember { mutableStateOf(false) }
     var mfaCode by remember { mutableStateOf("") }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginViewModel.kt
@@ -24,6 +24,10 @@ class LoginViewModel @Inject constructor(
     private val _serverUrl = MutableStateFlow(authRepository.getServerUrlSync() ?: "https://")
     val serverUrl: StateFlow<String> = _serverUrl
 
+    // Pre-fill username from the last session so a token expiry only
+    // requires re-entering the password, not everything from scratch.
+    val savedUsername: String? = authRepository.getCachedUsername()
+
     fun updateServerUrl(url: String) {
         _serverUrl.value = url
     }


### PR DESCRIPTION
Server URL was already preserved on 401 logout, but username was blank. Now pre-fills from cached user info so token expiry only requires re-entering the password.