### PR TITLE
feat: silently refresh auth token on 401 (Phase 1c)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 99
-        versionName = "0.9.81"
+        versionCode = 100
+        versionName = "0.9.82"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/remote/SapphoApi.kt
@@ -34,6 +34,12 @@ interface SapphoApi {
         @Body credentials: RegisterRequest
     ): Response<AuthResponse>
 
+    // Non-suspend, Call-returning refresh endpoint. The TokenAuthenticator runs
+    // synchronously (off the OkHttp dispatcher) and must call .execute(), so a
+    // suspend function cannot be used here.
+    @POST("api/auth/refresh")
+    fun refreshTokenCall(@Body request: RefreshTokenRequest): retrofit2.Call<AuthResponse>
+
     // Audiobooks
     @GET("api/audiobooks")
     suspend fun getAudiobooks(
@@ -522,6 +528,9 @@ data class RegisterRequest(
     val password: String,
     val email: String? = null
 )
+
+// Serializes to {"refreshToken":"..."} — camelCase, NO @SerializedName.
+data class RefreshTokenRequest(val refreshToken: String)
 
 data class MfaVerifyRequest(
     @com.google.gson.annotations.SerializedName("mfa_token")

--- a/app/src/main/java/com/sappho/audiobooks/data/remote/TokenAuthenticator.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/remote/TokenAuthenticator.kt
@@ -1,0 +1,89 @@
+package com.sappho.audiobooks.data.remote
+
+import android.util.Log
+import com.sappho.audiobooks.data.repository.AuthRepository
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+
+/**
+ * OkHttp [Authenticator] that transparently refreshes an expired access token
+ * when a request comes back with a 401.
+ *
+ * OkHttp invokes [authenticate] below the application interceptors (inside the
+ * RetryAndFollowUpInterceptor); whatever [Request] we return is retried. When
+ * refresh succeeds the application-level 401-trigger interceptor never sees the
+ * intermediate 401, so the user is NOT logged out. When we return null, the
+ * final 401 propagates up and the 401-trigger interceptor drives logout.
+ *
+ * @param refreshApi a SEPARATE SapphoApi built on a no-auth client so the
+ *   refresh call itself is never intercepted/re-authenticated (avoids loops).
+ */
+class TokenAuthenticator(
+    private val authRepository: AuthRepository,
+    private val refreshApi: SapphoApi
+) : Authenticator {
+
+    @Synchronized
+    override fun authenticate(route: Route?, response: Response): Request? {
+        // Bail out if we've already retried once — avoids infinite refresh loops.
+        if (responseCount(response) >= 2) {
+            Log.d(TAG, "Already retried once after refresh; giving up")
+            return null
+        }
+
+        // The access token that was actually used on the failed request.
+        val failedToken = response.request.header("Authorization")?.removePrefix("Bearer ")
+
+        // Another thread may have refreshed while we were blocked on the lock.
+        val current = authRepository.getTokenSync()
+        if (current != null && current != failedToken) {
+            Log.d(TAG, "Token already refreshed by another request; retrying with current token")
+            return response.request.newBuilder()
+                .header("Authorization", "Bearer $current")
+                .build()
+        }
+
+        val refreshToken = authRepository.getRefreshTokenSync()
+        if (refreshToken == null) {
+            Log.d(TAG, "No refresh token available; cannot refresh")
+            return null
+        }
+
+        return try {
+            val refreshResponse = refreshApi.refreshTokenCall(RefreshTokenRequest(refreshToken)).execute()
+            val body = refreshResponse.body()
+            val newToken = body?.token
+            if (refreshResponse.isSuccessful && newToken != null) {
+                Log.d(TAG, "Token refresh succeeded; rotating tokens and retrying request")
+                authRepository.saveTokens(newToken, body.refreshToken)
+                response.request.newBuilder()
+                    .header("Authorization", "Bearer $newToken")
+                    .build()
+            } else {
+                Log.d(TAG, "Token refresh failed (code=${refreshResponse.code()}); clearing tokens")
+                authRepository.clearToken()
+                null
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Token refresh threw; clearing tokens", e)
+            authRepository.clearToken()
+            null
+        }
+    }
+
+    private fun responseCount(response: Response): Int {
+        var r: Response? = response.priorResponse
+        var count = 1
+        while (r != null) {
+            count++
+            r = r.priorResponse
+        }
+        return count
+    }
+
+    companion object {
+        private const val TAG = "TokenAuthenticator"
+    }
+}

--- a/app/src/main/java/com/sappho/audiobooks/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/repository/AuthRepository.kt
@@ -58,8 +58,34 @@ class AuthRepository @Inject constructor(
         return securePrefs.getString(KEY_TOKEN, null)
     }
 
+    fun saveRefreshToken(token: String) {
+        securePrefs.edit().putString(KEY_REFRESH_TOKEN, token).apply()
+    }
+
+    fun getRefreshTokenSync(): String? {
+        return securePrefs.getString(KEY_REFRESH_TOKEN, null)
+    }
+
+    fun clearRefreshToken() {
+        securePrefs.edit().remove(KEY_REFRESH_TOKEN).apply()
+    }
+
+    /**
+     * Persist a freshly issued access token (and, when present, its rotated
+     * refresh token). Reuses [saveToken] so isAuthenticated stays in sync.
+     */
+    fun saveTokens(accessToken: String, refreshToken: String?) {
+        saveToken(accessToken)
+        if (refreshToken != null) {
+            saveRefreshToken(refreshToken)
+        }
+    }
+
     fun clearToken() {
-        securePrefs.edit().remove(KEY_TOKEN).apply()
+        securePrefs.edit()
+            .remove(KEY_TOKEN)
+            .remove(KEY_REFRESH_TOKEN)
+            .apply()
         _isAuthenticated.value = false
     }
 
@@ -239,6 +265,7 @@ class AuthRepository @Inject constructor(
     companion object {
         private const val PREFS_NAME = "secure_prefs"
         private const val KEY_TOKEN = "auth_token"
+        private const val KEY_REFRESH_TOKEN = "refresh_token"
         private const val KEY_SERVER_URL = "server_url"
         private const val KEY_USERNAME = "cached_username"
         private const val KEY_DISPLAY_NAME = "cached_display_name"

--- a/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
+++ b/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.sappho.audiobooks.data.remote.SapphoApi
+import com.sappho.audiobooks.data.remote.TokenAuthenticator
 import com.sappho.audiobooks.data.repository.AuthRepository
 import dagger.Module
 import dagger.Provides
@@ -15,6 +16,7 @@ import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonToken
 import com.google.gson.stream.JsonWriter
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -26,6 +28,8 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
+
+    private const val DEFAULT_BASE_URL = "http://192.168.1.100:3002"
 
     @Provides
     @Singleton
@@ -58,10 +62,8 @@ object NetworkModule {
             .create()
     }
 
-    @Provides
-    @Singleton
-    fun provideOkHttpClient(authRepository: AuthRepository): OkHttpClient {
-        val loggingInterceptor = HttpLoggingInterceptor().apply {
+    private fun provideLoggingInterceptor(): HttpLoggingInterceptor {
+        return HttpLoggingInterceptor().apply {
             // HEADERS level: logs request/response headers without buffering bodies.
             // BODY level would buffer entire audio files into memory for logging
             // and cause ProgressRequestBody.writeTo to be called twice.
@@ -71,83 +73,97 @@ object NetworkModule {
                 HttpLoggingInterceptor.Level.NONE
             }
         }
+    }
 
-        return OkHttpClient.Builder()
-            .addInterceptor(loggingInterceptor)
-            .addInterceptor { chain ->
-                val original = chain.request()
-                val originalHost = original.url.host
+    /**
+     * Interceptor that rewrites request URLs to the dynamically-configured
+     * server URL and (optionally) injects the auth header.
+     *
+     * @param addAuthHeader when true, adds `Authorization: Bearer <token>` if a
+     *   token is stored. The refresh client passes false because the refresh
+     *   token travels in the request body, not a header.
+     */
+    private fun serverUrlInterceptor(
+        authRepository: AuthRepository,
+        addAuthHeader: Boolean
+    ) = Interceptor { chain ->
+        val original = chain.request()
+        val originalHost = original.url.host
 
-                // Get the current server URL dynamically
-                val serverUrl = authRepository.getServerUrlSync()
-                val serverHost = serverUrl?.toHttpUrlOrNull()?.host
+        // Get the current server URL dynamically
+        val serverUrl = authRepository.getServerUrlSync()
+        val serverHost = serverUrl?.toHttpUrlOrNull()?.host
 
-                // Check if this is an external URL (not going to our server)
-                // External URLs should be passed through unchanged without auth headers
-                val isExternalUrl = serverHost != null &&
-                    originalHost != serverHost &&
-                    originalHost != "localhost" &&
-                    !originalHost.startsWith("192.168.") &&
-                    !originalHost.startsWith("10.") &&
-                    originalHost != "127.0.0.1"
+        // Check if this is an external URL (not going to our server)
+        // External URLs should be passed through unchanged without auth headers
+        val isExternalUrl = serverHost != null &&
+            originalHost != serverHost &&
+            originalHost != "localhost" &&
+            !originalHost.startsWith("192.168.") &&
+            !originalHost.startsWith("10.") &&
+            originalHost != "127.0.0.1"
 
-                if (isExternalUrl) {
-                    // External URL - pass through unchanged (no auth, no URL rewriting)
-                    chain.proceed(original)
-                } else {
-                    val request = if (serverUrl != null && serverUrl.isNotBlank()) {
-                        // Parse the server URL to extract components
-                        val baseUrl = if (!serverUrl.endsWith("/")) "$serverUrl/" else serverUrl
-                        val httpUrl = baseUrl.toHttpUrlOrNull()
+        if (isExternalUrl) {
+            // External URL - pass through unchanged (no auth, no URL rewriting)
+            chain.proceed(original)
+        } else {
+            fun withAuth(builder: okhttp3.Request.Builder): okhttp3.Request.Builder {
+                if (addAuthHeader) {
+                    val token = authRepository.getTokenSync()
+                    if (token != null) {
+                        builder.header("Authorization", "Bearer $token")
+                    }
+                }
+                return builder
+            }
 
-                        if (httpUrl != null) {
-                            // Rebuild the request URL with the dynamic server URL, preserving query parameters
-                            val urlBuilder = httpUrl.newBuilder()
-                                .addPathSegments(original.url.encodedPath.removePrefix("/"))
+            val request = if (serverUrl != null && serverUrl.isNotBlank()) {
+                // Parse the server URL to extract components
+                val baseUrl = if (!serverUrl.endsWith("/")) "$serverUrl/" else serverUrl
+                val httpUrl = baseUrl.toHttpUrlOrNull()
 
-                            // Copy all query parameters from the original request
-                            for (i in 0 until original.url.querySize) {
-                                val name = original.url.queryParameterName(i)
-                                val value = original.url.queryParameterValue(i)
-                                if (value != null) {
-                                    urlBuilder.addQueryParameter(name, value)
-                                }
-                            }
+                if (httpUrl != null) {
+                    // Rebuild the request URL with the dynamic server URL, preserving query parameters
+                    val urlBuilder = httpUrl.newBuilder()
+                        .addPathSegments(original.url.encodedPath.removePrefix("/"))
 
-                            val newUrl = urlBuilder.build()
-
-                            val requestBuilder = original.newBuilder().url(newUrl)
-
-                            // Add authorization header if token exists
-                            val token = authRepository.getTokenSync()
-                            if (token != null) {
-                                requestBuilder.header("Authorization", "Bearer $token")
-                            }
-
-                            requestBuilder.build()
-                        } else {
-                            // Fall back to original if URL parsing fails
-                            val requestBuilder = original.newBuilder()
-                            val token = authRepository.getTokenSync()
-                            if (token != null) {
-                                requestBuilder.header("Authorization", "Bearer $token")
-                            }
-                            requestBuilder.build()
+                    // Copy all query parameters from the original request
+                    for (i in 0 until original.url.querySize) {
+                        val name = original.url.queryParameterName(i)
+                        val value = original.url.queryParameterValue(i)
+                        if (value != null) {
+                            urlBuilder.addQueryParameter(name, value)
                         }
-                    } else {
-                        // No server URL set, use original
-                        val requestBuilder = original.newBuilder()
-                        val token = authRepository.getTokenSync()
-                        if (token != null) {
-                            requestBuilder.header("Authorization", "Bearer $token")
-                        }
-                        requestBuilder.build()
                     }
 
-                    chain.proceed(request)
+                    val newUrl = urlBuilder.build()
+                    withAuth(original.newBuilder().url(newUrl)).build()
+                } else {
+                    // Fall back to original if URL parsing fails
+                    withAuth(original.newBuilder()).build()
                 }
+            } else {
+                // No server URL set, use original
+                withAuth(original.newBuilder()).build()
             }
-            // Interceptor to detect auth errors (401 only — 403 is used for non-auth permission checks)
+
+            chain.proceed(request)
+        }
+    }
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(
+        authRepository: AuthRepository,
+        @Named("refreshApi") refreshApi: SapphoApi
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(provideLoggingInterceptor())
+            .addInterceptor(serverUrlInterceptor(authRepository, addAuthHeader = true))
+            // Interceptor to detect auth errors (401 only — 403 is used for non-auth permission checks).
+            // Runs ABOVE the Authenticator: on a successful refresh it sees the final 200
+            // (not the intermediate 401) and does NOT log out; on refresh failure it sees the
+            // final 401 and triggers logout.
             .addInterceptor { chain ->
                 val response = chain.proceed(chain.request())
                 if (response.code == 401) {
@@ -156,10 +172,47 @@ object NetworkModule {
                 }
                 response
             }
+            .authenticator(TokenAuthenticator(authRepository, refreshApi))
             .connectTimeout(60, TimeUnit.SECONDS)
             .readTimeout(5, TimeUnit.MINUTES)
             .writeTimeout(5, TimeUnit.MINUTES)
             .build()
+    }
+
+    /**
+     * No-auth OkHttpClient used ONLY for the token-refresh call. It shares the
+     * dynamic-server-URL rewrite (so the refresh hits the correct server) but
+     * has NO Authenticator (prevents infinite loops) and NO 401-trigger, and it
+     * does not attach the Authorization header (the refresh token is in the body).
+     */
+    @Provides
+    @Singleton
+    @Named("refreshClient")
+    fun provideRefreshOkHttpClient(authRepository: AuthRepository): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(provideLoggingInterceptor())
+            .addInterceptor(serverUrlInterceptor(authRepository, addAuthHeader = false))
+            .connectTimeout(60, TimeUnit.SECONDS)
+            .readTimeout(60, TimeUnit.SECONDS)
+            .writeTimeout(60, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    @Named("refreshApi")
+    fun provideRefreshApi(
+        @Named("refreshClient") client: OkHttpClient,
+        gson: Gson,
+        authRepository: AuthRepository
+    ): SapphoApi {
+        val baseUrl = authRepository.getServerUrlSync() ?: DEFAULT_BASE_URL
+        return Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(client)
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .build()
+            .create(SapphoApi::class.java)
     }
 
     @Provides
@@ -181,7 +234,7 @@ object NetworkModule {
         authRepository: AuthRepository
     ): Retrofit {
         // Get base URL from auth repository (where server URL is stored)
-        val baseUrl = authRepository.getServerUrlSync() ?: "http://192.168.1.100:3002"
+        val baseUrl = authRepository.getServerUrlSync() ?: DEFAULT_BASE_URL
 
         return Retrofit.Builder()
             .baseUrl(baseUrl)

--- a/app/src/main/java/com/sappho/audiobooks/domain/model/Audiobook.kt
+++ b/app/src/main/java/com/sappho/audiobooks/domain/model/Audiobook.kt
@@ -83,6 +83,7 @@ data class DeleteFileRequest(
 
 data class AuthResponse(
     val token: String? = null,
+    val refreshToken: String? = null,
     val user: User? = null,
     @SerializedName("mfa_required") val mfaRequired: Boolean = false,
     @SerializedName("mfa_token") val mfaToken: String? = null

--- a/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginViewModel.kt
@@ -59,7 +59,7 @@ class LoginViewModel @Inject constructor(
                             // MFA required - show code entry
                             _uiState.value = LoginUiState.MfaRequired(authResponse.mfaToken)
                         } else if (authResponse.token != null) {
-                            authRepository.saveToken(authResponse.token)
+                            authRepository.saveTokens(authResponse.token, authResponse.refreshToken)
                             _uiState.value = LoginUiState.Success
                         } else {
                             _uiState.value = LoginUiState.Error("Invalid response from server")
@@ -114,7 +114,7 @@ class LoginViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     response.body()?.let { authResponse ->
                         if (authResponse.token != null) {
-                            authRepository.saveToken(authResponse.token)
+                            authRepository.saveTokens(authResponse.token, authResponse.refreshToken)
                             _uiState.value = LoginUiState.Success
                         } else {
                             _uiState.value = LoginUiState.MfaError(mfaToken, "Invalid response from server")

--- a/app/src/test/java/com/sappho/audiobooks/data/remote/ReadingListApiTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/data/remote/ReadingListApiTest.kt
@@ -30,7 +30,8 @@ class ReadingListApiTest {
         every { authRepository.getServerUrlSync() } returns mockWebServer.url("/").toString()
         every { authRepository.getTokenSync() } returns "test-token"
 
-        val okHttpClient = NetworkModule.provideOkHttpClient(authRepository)
+        val refreshApi = mockk<SapphoApi>(relaxed = true)
+        val okHttpClient = NetworkModule.provideOkHttpClient(authRepository, refreshApi)
         val retrofit = Retrofit.Builder()
             .baseUrl(mockWebServer.url("/"))
             .client(okHttpClient)

--- a/app/src/test/java/com/sappho/audiobooks/data/remote/SapphoApiTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/data/remote/SapphoApiTest.kt
@@ -33,8 +33,10 @@ class SapphoApiTest {
         every { authRepository.getServerUrlSync() } returns mockWebServer.url("/").toString()
         every { authRepository.getTokenSync() } returns "test-token"
         
-        // Create API with mock server
-        val okHttpClient = NetworkModule.provideOkHttpClient(authRepository)
+        // Create API with mock server. The refresh API is unused by these tests
+        // (no 401s are enqueued), so a relaxed mock is sufficient.
+        val refreshApi = mockk<SapphoApi>(relaxed = true)
+        val okHttpClient = NetworkModule.provideOkHttpClient(authRepository, refreshApi)
         val retrofit = Retrofit.Builder()
             .baseUrl(mockWebServer.url("/"))
             .client(okHttpClient)

--- a/app/src/test/java/com/sappho/audiobooks/data/remote/TokenAuthenticatorTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/data/remote/TokenAuthenticatorTest.kt
@@ -1,0 +1,141 @@
+package com.sappho.audiobooks.data.remote
+
+import com.google.common.truth.Truth.assertThat
+import com.google.gson.Gson
+import com.sappho.audiobooks.data.repository.AuthRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+/**
+ * End-to-end tests for [TokenAuthenticator] using MockWebServer. A real
+ * OkHttpClient (with a simple auth-header interceptor + the authenticator) and
+ * a real Retrofit refresh API both point at the same MockWebServer instance.
+ */
+class TokenAuthenticatorTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var authRepository: AuthRepository
+    private lateinit var refreshApi: SapphoApi
+    private lateinit var client: OkHttpClient
+    private val gson = Gson()
+
+    @Before
+    fun setup() {
+        mockWebServer = MockWebServer()
+        authRepository = mockk(relaxed = true)
+
+        // Refresh API on the same server, no auth header (matches production wiring).
+        refreshApi = Retrofit.Builder()
+            .baseUrl(mockWebServer.url("/"))
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .build()
+            .create(SapphoApi::class.java)
+
+        // Main client: injects the current access token then delegates 401s to the authenticator.
+        client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val builder = chain.request().newBuilder()
+                authRepository.getTokenSync()?.let { token ->
+                    builder.header("Authorization", "Bearer $token")
+                }
+                chain.proceed(builder.build())
+            }
+            .authenticator(TokenAuthenticator(authRepository, refreshApi))
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    private fun protectedRequest(): Request =
+        Request.Builder().url(mockWebServer.url("/api/audiobooks")).build()
+
+    @Test
+    fun `refreshes token and retries request on 401 then succeeds`() {
+        // Given - a stored access token and refresh token
+        every { authRepository.getTokenSync() } returns "stale-access"
+        every { authRepository.getRefreshTokenSync() } returns "stored-refresh"
+
+        // 401 for the protected call, 200 for the refresh (rotated tokens), 200 for the retry
+        mockWebServer.enqueue(MockResponse().setResponseCode(401))
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"token":"fresh-access","refreshToken":"refresh-rotated"}""")
+        )
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("[]"))
+
+        // When
+        val response = client.newCall(protectedRequest()).execute()
+
+        // Then - the final response succeeds and tokens were rotated
+        assertThat(response.isSuccessful).isTrue()
+        assertThat(response.code).isEqualTo(200)
+        verify { authRepository.saveTokens("fresh-access", "refresh-rotated") }
+
+        // Verify the refresh request carried the camelCase refreshToken in the body
+        mockWebServer.takeRequest() // initial protected (401)
+        val refreshRequest = mockWebServer.takeRequest()
+        assertThat(refreshRequest.path).isEqualTo("/api/auth/refresh")
+        val refreshBody = refreshRequest.body.readUtf8()
+        assertThat(refreshBody).contains("\"refreshToken\":\"stored-refresh\"")
+
+        // Verify the retry used the fresh access token
+        val retryRequest = mockWebServer.takeRequest()
+        assertThat(retryRequest.getHeader("Authorization")).isEqualTo("Bearer fresh-access")
+
+        response.close()
+    }
+
+    @Test
+    fun `clears tokens and gives up when refresh fails`() {
+        // Given
+        every { authRepository.getTokenSync() } returns "stale-access"
+        every { authRepository.getRefreshTokenSync() } returns "stored-refresh"
+
+        // 401 for the protected call, 401 for the refresh
+        mockWebServer.enqueue(MockResponse().setResponseCode(401))
+        mockWebServer.enqueue(MockResponse().setResponseCode(401))
+
+        // When
+        val response = client.newCall(protectedRequest()).execute()
+
+        // Then - authenticator gives up, final response is 401, tokens cleared
+        assertThat(response.code).isEqualTo(401)
+        verify { authRepository.clearToken() }
+        verify(exactly = 0) { authRepository.saveTokens(any(), any()) }
+
+        response.close()
+    }
+
+    @Test
+    fun `does not attempt refresh when no refresh token stored`() {
+        // Given - access token present but no refresh token
+        every { authRepository.getTokenSync() } returns "stale-access"
+        every { authRepository.getRefreshTokenSync() } returns null
+
+        mockWebServer.enqueue(MockResponse().setResponseCode(401))
+
+        // When
+        val response = client.newCall(protectedRequest()).execute()
+
+        // Then - the call fails with 401 and no refresh request was made
+        assertThat(response.code).isEqualTo(401)
+        assertThat(mockWebServer.requestCount).isEqualTo(1)
+        verify(exactly = 0) { authRepository.saveTokens(any(), any()) }
+
+        response.close()
+    }
+}

--- a/app/src/test/java/com/sappho/audiobooks/data/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/data/repository/AuthRepositoryTest.kt
@@ -154,6 +154,85 @@ class AuthRepositoryTest {
     }
 
     @Test
+    fun `saveRefreshToken stores refresh token in encrypted preferences`() {
+        // Given
+        val refreshToken = "refresh-token-abc"
+
+        // When
+        repository.saveRefreshToken(refreshToken)
+
+        // Then
+        verify { editor.putString("refresh_token", refreshToken) }
+        verify { editor.apply() }
+    }
+
+    @Test
+    fun `getRefreshTokenSync returns stored refresh token`() {
+        // Given
+        val refreshToken = "refresh-token-abc"
+        every { sharedPreferences.getString("refresh_token", null) } returns refreshToken
+
+        // When
+        val result = repository.getRefreshTokenSync()
+
+        // Then
+        assertThat(result).isEqualTo(refreshToken)
+    }
+
+    @Test
+    fun `getRefreshTokenSync returns null when no refresh token stored`() {
+        // Given
+        every { sharedPreferences.getString("refresh_token", null) } returns null
+
+        // When
+        val result = repository.getRefreshTokenSync()
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `clearRefreshToken removes refresh token`() {
+        // When
+        repository.clearRefreshToken()
+
+        // Then
+        verify { editor.remove("refresh_token") }
+        verify { editor.apply() }
+    }
+
+    @Test
+    fun `saveTokens stores both access and refresh tokens`() {
+        // When
+        repository.saveTokens("access-123", "refresh-456")
+
+        // Then
+        verify { editor.putString("auth_token", "access-123") }
+        verify { editor.putString("refresh_token", "refresh-456") }
+    }
+
+    @Test
+    fun `saveTokens stores only access token when refresh token is null`() {
+        // When
+        repository.saveTokens("access-123", null)
+
+        // Then
+        verify { editor.putString("auth_token", "access-123") }
+        verify(exactly = 0) { editor.putString("refresh_token", any()) }
+    }
+
+    @Test
+    fun `clearToken removes refresh token too`() {
+        // When
+        repository.clearToken()
+
+        // Then
+        verify { editor.remove("auth_token") }
+        verify { editor.remove("refresh_token") }
+        verify { editor.apply() }
+    }
+
+    @Test
     fun `saveServerUrl trims whitespace from URL`() {
         // Given
         val url = "  https://sappho.example.com  "

--- a/app/src/test/java/com/sappho/audiobooks/presentation/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/presentation/login/LoginViewModelTest.kt
@@ -75,7 +75,7 @@ class LoginViewModelTest {
         
         coEvery { 
             api.login(LoginRequest(username, password)) 
-        } returns Response.success(AuthResponse(token, user))
+        } returns Response.success(AuthResponse(token = token, user = user))
         
         // When
         viewModel.uiState.test {
@@ -87,8 +87,8 @@ class LoginViewModelTest {
             assertThat(awaitItem()).isEqualTo(LoginUiState.Loading)
             assertThat(awaitItem()).isEqualTo(LoginUiState.Success)
             
-            // Verify token was saved
-            verify { authRepository.saveToken(token) }
+            // Verify tokens were saved (access + refresh; refreshToken null here)
+            verify { authRepository.saveTokens(token, null) }
         }
     }
     


### PR DESCRIPTION
Closes #264

## What
Wires the Android client to the backend's rotating refresh tokens (server v0.10.0) so sessions renew in the background instead of bouncing to the login screen when the access token expires.

## How
- `AuthResponse` gains `refreshToken` (**camelCase** JSON — verified against the backend; this specific field is not snake_case).
- `AuthRepository` stores the refresh token in EncryptedSharedPreferences, rotates both via `saveTokens()`; `clearToken()` now wipes both.
- New `RefreshTokenRequest` + a **non-suspend** `refreshTokenCall(): Call<AuthResponse>` (an OkHttp `Authenticator` runs synchronously and must `.execute()`).
- **`TokenAuthenticator`** (OkHttp `Authenticator`): on a 401 it refreshes once and replays the request.
  - `@Synchronized`; if another thread already rotated the token while it was blocked, it retries with the **current** token instead of refreshing again — so N concurrent 401s trigger **one** rotation and never trip the backend's reuse-detection (which revokes the whole token family).
  - `responseCount` caps retries at one (no loops); refresh runs on a **separate no-auth client** so it can't recurse; refresh failure clears tokens and lets the final 401 drive the existing logout.
- `NetworkModule`: extracted the dynamic-server-URL rewrite into a shared interceptor (auth header optional), added a no-auth refresh client + refresh `SapphoApi`, wired the `Authenticator` onto the main client. **No Hilt cycle.**
- `LoginViewModel` persists the refresh token on login and MFA verify.

## Interceptor ordering (why this is safe)
The existing 401-trigger is an application interceptor, so it sees the **final** response after the Authenticator's retry: on a successful refresh it sees 200 (no logout); on a failed refresh it sees the final 401 and drives logout. Sessions predating this feature have no refresh token → the Authenticator returns null → old behavior preserved.

## Tests
New: `TokenAuthenticatorTest` (MockWebServer end-to-end — happy-path rotate+retry, refresh-fails→logout, no-refresh-token→401) + `AuthRepository` refresh-token storage/rotation/clear. Full unit suite green (`testDebugUnitTest` BUILD SUCCESSFUL).

## Version
Bumped versionCode 100 / versionName 0.9.82 (required for the Play Store deploy on merge).

## Testing needed on device
Please verify a real expired-token flow against Sappho-Dev/prod: stay logged in past a token expiry (or revoke server-side) and confirm the app keeps working without a forced re-login, and that a genuinely failed/revoked refresh cleanly returns to the login screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)