### PR TITLE
fix: don't hang Home forever when server is unreachable (Phase 2)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 100
-        versionName = "0.9.82"
+        versionCode = 101
+        versionName = "0.9.83"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModel.kt
@@ -186,25 +186,32 @@ class AudiobookDetailViewModel @Inject constructor(
             _isLoading.value = true
             _isProgressLoading.value = true
 
-            // If offline, load from downloaded data and merge with pending progress
-            if (!networkMonitor.isOnline.value) {
-                val downloadedBook = downloadManager.getDownloadedBook(id)
-                if (downloadedBook != null) {
-                    _audiobook.value = downloadedBook.audiobook
-                    _chapters.value = downloadedBook.chapters
+            // Seed from downloaded data first (if we have it) so a downloaded
+            // book's detail screen is usable immediately — even when the device
+            // is online but the SERVER is unreachable, where the refresh below
+            // would otherwise block on a long socket timeout and hang the screen.
+            val downloadedBook = downloadManager.getDownloadedBook(id)
+            if (downloadedBook != null) {
+                _audiobook.value = downloadedBook.audiobook
+                _chapters.value = downloadedBook.chapters
 
-                    // Check for pending progress that may be more recent than downloaded data
-                    val pendingProgress = downloadManager.pendingProgress.value[id]
-                    if (pendingProgress != null) {
-                        // Use pending progress if it exists (more recent than downloaded data)
-                        _progress.value = Progress(
-                            position = pendingProgress.position,
-                            completed = downloadedBook.audiobook.progress?.completed ?: 0
-                        )
-                    } else {
-                        _progress.value = downloadedBook.audiobook.progress
-                    }
+                // Check for pending progress that may be more recent than downloaded data
+                val pendingProgress = downloadManager.pendingProgress.value[id]
+                if (pendingProgress != null) {
+                    // Use pending progress if it exists (more recent than downloaded data)
+                    _progress.value = Progress(
+                        position = pendingProgress.position,
+                        completed = downloadedBook.audiobook.progress?.completed ?: 0
+                    )
+                } else {
+                    _progress.value = downloadedBook.audiobook.progress
                 }
+                _isProgressLoading.value = false
+                _isLoading.value = false
+            }
+
+            // Device offline — nothing to refresh from the server.
+            if (!networkMonitor.isOnline.value) {
                 _isProgressLoading.value = false
                 _isLoading.value = false
                 return@launch
@@ -294,8 +301,8 @@ class AudiobookDetailViewModel @Inject constructor(
                     Log.e(TAG, "Failed to load files", e)
                 }
             } catch (e: Exception) {
-                // Network error - try to load from downloaded data with pending progress
-                val downloadedBook = downloadManager.getDownloadedBook(id)
+                // Network error - fall back to the downloaded data seeded above
+                // (if any), refreshing pending progress in case it changed.
                 if (downloadedBook != null) {
                     _audiobook.value = downloadedBook.audiobook
                     _chapters.value = downloadedBook.chapters

--- a/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
@@ -104,7 +104,11 @@ fun HomeScreen(
         }
     }
 
-    if (isLoading) {
+    // Only take over the whole screen with the skeleton when there's nothing
+    // cached to show yet. If downloaded books exist they render immediately
+    // (and the feed refreshes underneath), so an unreachable server can't hide
+    // them behind an endless loading state.
+    if (isLoading && downloadedBooks.isEmpty()) {
         SkeletonHomeScreen()
     } else {
         Column(

--- a/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeViewModel.kt
@@ -18,6 +18,9 @@ import kotlinx.coroutines.flow.collectLatest
 import android.util.Log
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.CancellationException
 import com.sappho.audiobooks.sync.SyncStatusManager
 import javax.inject.Inject
 
@@ -33,6 +36,8 @@ class HomeViewModel @Inject constructor(
 
     companion object {
         private const val TAG = "HomeViewModel"
+        // Cap the home-feed load so an unreachable-but-online server can't hang it.
+        private const val FEED_TIMEOUT_MS = 10_000L
     }
 
     private val _inProgress = MutableStateFlow<List<Audiobook>>(emptyList())
@@ -96,105 +101,106 @@ class HomeViewModel @Inject constructor(
 
     private fun loadData() {
         if (!networkMonitor.isOnline.value) {
-            // Don't try to load if we know we're offline
+            // Device itself has no network — offline, surface downloads.
+            _isOffline.value = true
             return
         }
 
         viewModelScope.launch {
             performanceMonitor.measureTime("Home Data Load") {
                 _isLoading.value = true
-                try {
-                // Load all data in parallel for better performance
-                val favoritesDeferred = async {
-                    try {
-                        api.getFavorites()
-                    } catch (e: Exception) {
-                        null
-                    }
-                }
-                
-                val inProgressDeferred = async { 
-                    try {
-                        api.getInProgress(10)
-                    } catch (e: Exception) {
-                        null
-                    }
-                }
-                
-                val recentlyAddedDeferred = async { 
-                    try {
-                        api.getRecentlyAdded(10) 
-                    } catch (e: Exception) {
-                        null
-                    }
-                }
-                
-                val upNextDeferred = async { 
-                    try {
-                        api.getUpNext(10)
-                    } catch (e: Exception) {
-                        null
-                    }
-                }
-                
-                val finishedDeferred = async {
-                    try {
-                        api.getFinished(10)
-                    } catch (e: Exception) {
-                        null
-                    }
-                }
-
-                // Wait for favorites first to apply status to other lists
-                val favoriteIds = mutableSetOf<Int>()
-                val favoritesResponse = favoritesDeferred.await()
-                if (favoritesResponse?.isSuccessful == true) {
-                    favoriteIds.addAll(favoritesResponse.body()?.map { it.id } ?: emptyList())
-                }
-
-                // Helper function to apply favorite status to book lists
-                fun List<Audiobook>.withFavoriteStatus(): List<Audiobook> {
-                    return map { book ->
-                        if (favoriteIds.contains(book.id)) book.copy(isFavorite = true) else book
-                    }
-                }
-
-                // Process all responses in parallel
-                val inProgressResponse = inProgressDeferred.await()
-                if (inProgressResponse?.isSuccessful == true) {
-                    _inProgress.value = (inProgressResponse.body() ?: emptyList()).withFavoriteStatus()
-                }
-
-                val recentlyAddedResponse = recentlyAddedDeferred.await()
-                if (recentlyAddedResponse?.isSuccessful == true) {
-                    _recentlyAdded.value = (recentlyAddedResponse.body() ?: emptyList()).withFavoriteStatus()
-                }
-
-                val upNextResponse = upNextDeferred.await()
-                if (upNextResponse?.isSuccessful == true) {
-                    val upNextBooks = (upNextResponse.body() ?: emptyList()).withFavoriteStatus()
-                    // Prioritize next book in series of the currently playing book
-                    _upNext.value = prioritizeUpNext(upNextBooks, _inProgress.value)
-                }
-
-                val finishedResponse = finishedDeferred.await()
-                if (finishedResponse?.isSuccessful == true) {
-                    _finished.value = (finishedResponse.body() ?: emptyList()).withFavoriteStatus()
-                }
-                // Data loaded successfully from server — clear any stale sync state.
-                // Pending progress items are now stale since the server has the real
-                // position from successful streaming syncs.
-                downloadManager.clearAllPendingProgress()
-                syncStatusManager.updateSyncStatus(lastSyncSuccess = true)
-            } catch (e: Exception) {
+                // The device can be online while the SERVER is unreachable (it's
+                // down, or we're off its network). Those calls would otherwise
+                // block on OkHttp's read timeout (minutes) and leave Home spinning
+                // forever, so cap the whole load. On timeout or total failure we
+                // fall back to the offline UI (downloaded books).
+                val reachedServer = try {
+                    withTimeoutOrNull(FEED_TIMEOUT_MS) { loadHomeFeed() } ?: false
+                } catch (e: Exception) {
                     Log.e(TAG, "Failed to load home data", e)
+                    false
                 } finally {
                     _isLoading.value = false
                     performanceMonitor.logMemoryUsage("After Home Data Load")
                 }
+                _isOffline.value = !reachedServer
             }
         }
     }
+
+    /**
+     * Loads the home-feed sections in parallel. Returns true if the server was
+     * reachable (at least one request produced an HTTP response), false if every
+     * request failed with a network error.
+     */
+    private suspend fun loadHomeFeed(): Boolean = coroutineScope {
+        val favoritesDeferred = async { safeCall { api.getFavorites() } }
+        val inProgressDeferred = async { safeCall { api.getInProgress(10) } }
+        val recentlyAddedDeferred = async { safeCall { api.getRecentlyAdded(10) } }
+        val upNextDeferred = async { safeCall { api.getUpNext(10) } }
+        val finishedDeferred = async { safeCall { api.getFinished(10) } }
+
+        // Favorites first so we can flag favorite books in the other lists.
+        val favoritesResponse = favoritesDeferred.await()
+        val favoriteIds = mutableSetOf<Int>()
+        if (favoritesResponse?.isSuccessful == true) {
+            favoriteIds.addAll(favoritesResponse.body()?.map { it.id } ?: emptyList())
+        }
+
+        fun List<Audiobook>.withFavoriteStatus(): List<Audiobook> =
+            map { book -> if (favoriteIds.contains(book.id)) book.copy(isFavorite = true) else book }
+
+        // A non-null response means we actually reached the server (even an HTTP
+        // error counts); all-null means the server was unreachable.
+        var reached = favoritesResponse != null
+
+        val inProgressResponse = inProgressDeferred.await()
+        if (inProgressResponse != null) reached = true
+        if (inProgressResponse?.isSuccessful == true) {
+            _inProgress.value = (inProgressResponse.body() ?: emptyList()).withFavoriteStatus()
+        }
+
+        val recentlyAddedResponse = recentlyAddedDeferred.await()
+        if (recentlyAddedResponse != null) reached = true
+        if (recentlyAddedResponse?.isSuccessful == true) {
+            _recentlyAdded.value = (recentlyAddedResponse.body() ?: emptyList()).withFavoriteStatus()
+        }
+
+        val upNextResponse = upNextDeferred.await()
+        if (upNextResponse != null) reached = true
+        if (upNextResponse?.isSuccessful == true) {
+            val upNextBooks = (upNextResponse.body() ?: emptyList()).withFavoriteStatus()
+            _upNext.value = prioritizeUpNext(upNextBooks, _inProgress.value)
+        }
+
+        val finishedResponse = finishedDeferred.await()
+        if (finishedResponse != null) reached = true
+        if (finishedResponse?.isSuccessful == true) {
+            _finished.value = (finishedResponse.body() ?: emptyList()).withFavoriteStatus()
+        }
+
+        if (reached) {
+            // Server has the real positions from successful syncs — stale pending
+            // items can be dropped.
+            downloadManager.clearAllPendingProgress()
+            syncStatusManager.updateSyncStatus(lastSyncSuccess = true)
+        }
+        reached
+    }
+
+    /**
+     * Runs an API call, swallowing network errors (returns null) while letting
+     * coroutine cancellation propagate — so the feed timeout actually cancels
+     * the in-flight request instead of being caught and ignored.
+     */
+    private suspend fun <T> safeCall(block: suspend () -> retrofit2.Response<T>): retrofit2.Response<T>? =
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            null
+        }
 
     fun refresh() {
         loadData()

--- a/app/src/test/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModelTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModelTest.kt
@@ -54,6 +54,9 @@ class AudiobookDetailViewModelTest {
 
         every { authRepository.getServerUrlSync() } returns "https://test.com"
         every { networkMonitor.isOnline } returns MutableStateFlow(true)
+        // Default: the book isn't downloaded. loadAudiobook() now seeds from
+        // downloaded data first, so the online-path tests need this to be null.
+        every { downloadManager.getDownloadedBook(any()) } returns null
         
         viewModel = AudiobookDetailViewModel(
             context = context,


### PR DESCRIPTION
Closes #266

Device online, **server unreachable** (down / off its network). Offline handling keyed only on device connectivity (`ConnectivityManager`), so `isOffline` stayed `false` and the UI blocked on OkHttp's **5-minute** read timeout — "nothing ever loads, it just sits there forever." Two screens had this:

## Home
- `HomeViewModel.loadData()` now caps the feed with `withTimeoutOrNull(10s)`. Timeout / all-requests-failed ⇒ server unreachable ⇒ `isOffline = true`, so the **Downloaded Books** section + offline banner appear. Extracted `loadHomeFeed()`; reachability = any request returning an HTTP response.
- `safeCall()` swallows network errors but **rethrows `CancellationException`** so the timeout actually cancels the in-flight calls.
- `HomeScreen` shows the full-screen skeleton only when there are no downloaded books, so downloads render immediately.

## Detail
- `AudiobookDetailViewModel.loadAudiobook()` only took the offline path when the *device* was offline; device-online + server-down fell through to `api.getAudiobook()` and hung. It now **seeds from downloaded data first** and drops `isLoading` immediately, so a downloaded book's detail screen is usable and **Play works at once**; the server refresh runs in the background (cancelled when the screen closes).

Downloaded playback was already local-file/zero-network; these fixes make downloads *reachable* in the server-down case. Same fix for iOS: mondominator/sapphoios#88.

## Version
versionCode 101 / versionName 0.9.83.

## Testing
`./gradlew testDebugUnitTest` — 179 tests, BUILD SUCCESSFUL. On-device repro: device online + server stopped → cold-launch shows downloaded books within ~10s (no endless skeleton), tap a download → detail is immediate → plays offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)