### PR TITLE
fix: critical audit fixes — auth token safety, download cancellation, ANR-free progress sync (0.9.84)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 101
-        versionName = "0.9.83"
+        versionCode = 102
+        versionName = "0.9.84"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/data/remote/TokenAuthenticator.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/remote/TokenAuthenticator.kt
@@ -2,6 +2,7 @@ package com.sappho.audiobooks.data.remote
 
 import android.util.Log
 import com.sappho.audiobooks.data.repository.AuthRepository
+import java.io.IOException
 import okhttp3.Authenticator
 import okhttp3.Request
 import okhttp3.Response
@@ -61,15 +62,27 @@ class TokenAuthenticator(
                 response.request.newBuilder()
                     .header("Authorization", "Bearer $newToken")
                     .build()
-            } else {
-                Log.d(TAG, "Token refresh failed (code=${refreshResponse.code()}); clearing tokens")
+            } else if (refreshResponse.code() == 401 || refreshResponse.code() == 403) {
+                // Definitive rejection: the refresh token itself is invalid/revoked.
+                // Clearing tokens (and letting the final 401 drive logout) is correct.
+                Log.d(TAG, "Refresh token rejected (code=${refreshResponse.code()}); clearing tokens")
                 authRepository.clearToken()
                 null
+            } else {
+                // Transient server failure (5xx, restart, proxy error). Do NOT destroy
+                // valid credentials — fail this call as a network error so the final
+                // 401 never reaches the logout-trigger interceptor, and a later
+                // request can retry the refresh.
+                Log.w(TAG, "Token refresh failed transiently (code=${refreshResponse.code()}); keeping tokens")
+                throw IOException("Token refresh failed transiently (HTTP ${refreshResponse.code()})")
             }
-        } catch (e: Exception) {
-            Log.e(TAG, "Token refresh threw; clearing tokens", e)
-            authRepository.clearToken()
-            null
+        } catch (e: IOException) {
+            // Network blip / timeout / server briefly down. Keep tokens and propagate
+            // as a call failure — the request errors out, but credentials survive and
+            // the next request retries the refresh. (Returning null here would surface
+            // the original 401 and log the user out via the auth-error interceptor.)
+            Log.w(TAG, "Token refresh network failure; keeping tokens for retry", e)
+            throw e
         }
     }
 

--- a/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
@@ -44,15 +44,16 @@ import com.sappho.audiobooks.data.repository.UserPreferencesRepository
 import com.sappho.audiobooks.domain.model.Audiobook
 import com.sappho.audiobooks.download.DownloadManager
 import com.sappho.audiobooks.presentation.theme.Timing
+import com.sappho.audiobooks.sync.ProgressSyncWorker
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
@@ -88,6 +89,10 @@ class AudioPlaybackService : MediaLibraryService() {
 
     private var audioManager: AudioManager? = null
     private var audioFocusRequest: AudioFocusRequest? = null
+    // True when WE paused because of a transient focus loss (phone call,
+    // navigation prompt). On AUDIOFOCUS_GAIN we auto-resume only in that case —
+    // never after a user-initiated pause or a permanent focus loss.
+    private var pausedByTransientFocusLoss = false
     private var noisyReceiver: BecomingNoisyReceiver? = null
 
     // Track playback session start time for progress sync delay
@@ -303,11 +308,14 @@ class AudioPlaybackService : MediaLibraryService() {
             .setOnAudioFocusChangeListener { focusChange ->
                 when (focusChange) {
                     AudioManager.AUDIOFOCUS_LOSS -> {
-                        // Lost focus permanently - pause playback
+                        // Lost focus permanently - pause playback, no auto-resume
+                        pausedByTransientFocusLoss = false
                         player?.pause()
                     }
                     AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
-                        // Lost focus temporarily - pause playback
+                        // Lost focus temporarily (call, navigation prompt) - pause
+                        // and remember to resume when focus returns
+                        pausedByTransientFocusLoss = player?.isPlaying == true
                         player?.pause()
                     }
                     AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
@@ -315,8 +323,13 @@ class AudioPlaybackService : MediaLibraryService() {
                         player?.volume = 0.3f
                     }
                     AudioManager.AUDIOFOCUS_GAIN -> {
-                        // Regained focus - restore volume and resume if needed
+                        // Regained focus - restore volume, and resume playback if
+                        // WE paused it for a transient loss (standard audio-app UX)
                         player?.volume = 1.0f
+                        if (pausedByTransientFocusLoss) {
+                            pausedByTransientFocusLoss = false
+                            player?.play()
+                        }
                     }
                 }
             }
@@ -1283,7 +1296,8 @@ class AudioPlaybackService : MediaLibraryService() {
                 }
                 mediaUri = Uri.parse("$serverUrl/api/audiobooks/${audiobook.id}/stream?token=$token")
                 isPlayingLocalFile = false
-                android.util.Log.d("AudioPlaybackService", "Streaming from: $mediaUri")
+                // SECURITY: never log mediaUri — it carries the auth token as a query param
+                android.util.Log.d("AudioPlaybackService", "Streaming audiobook ${audiobook.id} from server")
             }
 
             // Build cover art URI for notification
@@ -1747,24 +1761,15 @@ class AudioPlaybackService : MediaLibraryService() {
     override fun onTaskRemoved(rootIntent: Intent?) {
         val isPlaying = player?.isPlaying == true
 
-        // Sync progress synchronously
+        // Persist progress without blocking: save locally, then let WorkManager
+        // push it. runBlocking { api.updateProgress(...) } here ran on the main
+        // thread and could ANR the process while OkHttp waited out its timeouts.
         val book = playerState.currentAudiobook.value
         val position = playerState.currentPosition.value.toInt()
         val duration = playerState.duration.value.toInt()
         if (book != null && position > 0 && (duration == 0 || (duration - position) >= 30)) {
-            // Always save locally first as a safety net
             downloadManager.saveOfflineProgress(book.id, position)
-            runBlocking {
-                try {
-                    api.updateProgress(
-                        book.id,
-                        ProgressUpdateRequest(position = position, completed = 0, state = if (isPlaying) "playing" else "paused")
-                    )
-                    downloadManager.clearPendingProgress(book.id)
-                } catch (_: Exception) {
-                    // Saved locally above — ProgressSyncWorker will retry
-                }
-            }
+            ProgressSyncWorker.enqueue(this)
         }
 
         if (isPlaying) {
@@ -1791,31 +1796,20 @@ class AudioPlaybackService : MediaLibraryService() {
 
     override fun onDestroy() {
         instance = null
-        // Sync progress synchronously — the coroutine-based syncProgress() won't complete
-        // because serviceScope is about to be cancelled
+        // Persist progress without blocking the main thread (see onTaskRemoved):
+        // save locally, then hand off to WorkManager — it survives service death.
         val book = playerState.currentAudiobook.value
         val position = playerState.currentPosition.value.toInt()
         val duration = playerState.duration.value.toInt()
         if (book != null && position > 0 && (duration == 0 || (duration - position) >= 30)) {
-            // Always save locally first as a safety net
             downloadManager.saveOfflineProgress(book.id, position)
-            runBlocking {
-                try {
-                    api.updateProgress(
-                        book.id,
-                        ProgressUpdateRequest(position = position, completed = 0, state = "stopped")
-                    )
-                    downloadManager.clearPendingProgress(book.id)
-                } catch (_: Exception) {
-                    // Saved locally above — ProgressSyncWorker will retry
-                }
-            }
+            ProgressSyncWorker.enqueue(this)
         }
         player?.release()
         mediaLibrarySession?.release()
-        progressSyncJob?.cancel()
-        positionUpdateJob?.cancel()
-        pauseTimeoutJob?.cancel()
+        // Cancel the whole scope — individual job cancels missed sleepTimerJob
+        // and the onTaskRemoved fallback-timeout coroutine, which leaked.
+        serviceScope.cancel()
         abandonAudioFocus()
         unregisterNoisyReceiver()
         unregisterNotificationActionReceiver()

--- a/app/src/main/java/com/sappho/audiobooks/service/DownloadService.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/DownloadService.kt
@@ -19,10 +19,14 @@ import com.sappho.audiobooks.download.DownloadManager
 import com.sappho.audiobooks.download.DownloadState
 import com.sappho.audiobooks.presentation.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -47,6 +51,10 @@ class DownloadService : Service() {
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var downloadJob: Job? = null
+    // The in-flight OkHttp call. Cancelling the coroutine Job alone does NOT
+    // interrupt the blocking InputStream.read loop — the call itself must be
+    // cancelled so the socket read aborts immediately.
+    private var downloadCall: okhttp3.Call? = null
     private var currentDownloadId: Int? = null
 
     private val downloadClient = OkHttpClient.Builder()
@@ -171,6 +179,10 @@ class DownloadService : Service() {
     }
 
     private fun startDownload(audiobookId: Int, title: String, author: String) {
+        // Cancel any in-flight download first — otherwise a second START_DOWNLOAD
+        // intent leaves two loops writing DownloadManager state concurrently.
+        downloadJob?.cancel()
+        downloadCall?.cancel()
         currentDownloadId = audiobookId
 
         // Update DownloadManager state
@@ -194,7 +206,9 @@ class DownloadService : Service() {
                     .addHeader("Authorization", "Bearer $token")
                     .build()
 
-                val response = downloadClient.newCall(request).execute()
+                val call = downloadClient.newCall(request)
+                downloadCall = call
+                val response = call.execute()
 
                 if (!response.isSuccessful) {
                     throw Exception("Download failed: ${response.code}")
@@ -203,54 +217,56 @@ class DownloadService : Service() {
                 val body = response.body ?: throw Exception("Empty response body")
                 val contentLength = body.contentLength()
 
-                val downloadsDir = File(filesDir, "audiobooks").also { 
+                val downloadsDir = File(filesDir, "audiobooks").also {
                     if (!it.exists() && !it.mkdirs()) {
                         throw IOException("Failed to create download directory")
                     }
                 }
                 val file = File(downloadsDir, "audiobook_$audiobookId.m4b")
-                
+
                 // Check available storage space
                 val freeSpace = downloadsDir.freeSpace
                 if (contentLength > 0 && freeSpace < contentLength * 1.1) { // 10% buffer
                     throw IOException("Insufficient storage space. Need ${contentLength / 1024 / 1024}MB, but only ${freeSpace / 1024 / 1024}MB available")
                 }
-                
-                val outputStream = FileOutputStream(file)
-                val inputStream = body.byteStream()
 
-                val buffer = ByteArray(8192)
-                var bytesRead: Int
-                var totalBytesRead = 0L
-                var lastProgress = 0
+                // use{} guarantees both streams close on every path (they used to
+                // leak whenever the loop threw).
+                FileOutputStream(file).use { outputStream ->
+                    body.byteStream().use { inputStream ->
+                        val buffer = ByteArray(8192)
+                        var bytesRead: Int
+                        var totalBytesRead = 0L
+                        var lastProgress = 0
 
-                while (inputStream.read(buffer).also { bytesRead = it } != -1) {
-                    outputStream.write(buffer, 0, bytesRead)
-                    totalBytesRead += bytesRead
+                        while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                            // Surface coroutine cancellation between chunks
+                            ensureActive()
+                            outputStream.write(buffer, 0, bytesRead)
+                            totalBytesRead += bytesRead
 
-                    val progress = if (contentLength > 0) {
-                        ((totalBytesRead.toFloat() / contentLength.toFloat()) * 100).toInt()
-                    } else {
-                        0
-                    }
+                            val progress = if (contentLength > 0) {
+                                ((totalBytesRead.toFloat() / contentLength.toFloat()) * 100).toInt()
+                            } else {
+                                0
+                            }
 
-                    // Update notification every 1%
-                    if (progress != lastProgress) {
-                        lastProgress = progress
-                        updateNotification(title, author, progress)
+                            // Update notification every 1%
+                            if (progress != lastProgress) {
+                                lastProgress = progress
+                                updateNotification(title, author, progress)
 
-                        // Update DownloadManager state
-                        downloadManager.updateDownloadStateExternal(audiobookId, DownloadState(
-                            audiobookId = audiobookId,
-                            progress = progress / 100f,
-                            isDownloading = true,
-                            isCompleted = false
-                        ))
+                                // Update DownloadManager state
+                                downloadManager.updateDownloadStateExternal(audiobookId, DownloadState(
+                                    audiobookId = audiobookId,
+                                    progress = progress / 100f,
+                                    isDownloading = true,
+                                    isCompleted = false
+                                ))
+                            }
+                        }
                     }
                 }
-
-                outputStream.close()
-                inputStream.close()
 
                 // Fetch audiobook details and chapters
                 val audiobookResponse = api.getAudiobook(audiobookId)
@@ -289,45 +305,61 @@ class DownloadService : Service() {
                     notificationManager.notify(NOTIFICATION_ID + 1, createCompletedNotification(title, true))
                 }
 
+            } catch (e: CancellationException) {
+                // User-initiated cancel or service teardown: clean up quietly,
+                // no "Download Failed" notification, and rethrow so the coroutine
+                // machinery sees the cancellation.
+                Log.d(TAG, "Download cancelled")
+                cleanUpPartialFile(audiobookId)
+                throw e
             } catch (e: Exception) {
-                Log.e(TAG, "Download failed", e)
+                // OkHttp surfaces call.cancel() as IOException("Canceled") from the
+                // blocking read — that is a cancel, not a failure.
+                if (downloadCall?.isCanceled() == true || !isActive) {
+                    Log.d(TAG, "Download cancelled (call aborted)")
+                    cleanUpPartialFile(audiobookId)
+                } else {
+                    Log.e(TAG, "Download failed", e)
+                    cleanUpPartialFile(audiobookId)
 
-                // Clean up partial download
-                try {
-                    val downloadsDir = File(filesDir, "audiobooks")
-                    val file = File(downloadsDir, "audiobook_$audiobookId.m4b")
-                    if (file.exists()) {
-                        file.delete()
+                    val errorMessage = when (e) {
+                        is IOException -> e.message ?: "Download failed"
+                        is SecurityException -> "Permission denied"
+                        else -> "Download failed: ${e.message}"
                     }
-                } catch (deleteError: Exception) {
-                    Log.e(TAG, "Failed to clean up partial download", deleteError)
-                }
 
-                val errorMessage = when (e) {
-                    is IOException -> e.message ?: "Download failed"
-                    is SecurityException -> "Permission denied"
-                    is OutOfMemoryError -> "Out of memory"
-                    else -> "Download failed: ${e.message}"
-                }
+                    downloadManager.updateDownloadStateExternal(audiobookId, DownloadState(
+                        audiobookId = audiobookId,
+                        progress = 0f,
+                        isDownloading = false,
+                        isCompleted = false,
+                        error = errorMessage
+                    ))
 
-                downloadManager.updateDownloadStateExternal(audiobookId, DownloadState(
-                    audiobookId = audiobookId,
-                    progress = 0f,
-                    isDownloading = false,
-                    isCompleted = false,
-                    error = errorMessage
-                ))
-
-                // Show failure notification with specific error
-                withContext(Dispatchers.Main) {
-                    val notificationManager = getSystemService(NotificationManager::class.java)
-                    notificationManager.notify(NOTIFICATION_ID + 1, createCompletedNotification(title, false, errorMessage))
+                    // Show failure notification with specific error
+                    withContext(Dispatchers.Main) {
+                        val notificationManager = getSystemService(NotificationManager::class.java)
+                        notificationManager.notify(NOTIFICATION_ID + 1, createCompletedNotification(title, false, errorMessage))
+                    }
                 }
             } finally {
+                downloadCall = null
                 currentDownloadId = null
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
             }
+        }
+    }
+
+    private fun cleanUpPartialFile(audiobookId: Int) {
+        try {
+            val downloadsDir = File(filesDir, "audiobooks")
+            val file = File(downloadsDir, "audiobook_$audiobookId.m4b")
+            if (file.exists()) {
+                file.delete()
+            }
+        } catch (deleteError: Exception) {
+            Log.e(TAG, "Failed to clean up partial download", deleteError)
         }
     }
 
@@ -338,6 +370,9 @@ class DownloadService : Service() {
 
     private fun cancelCurrentDownload() {
         downloadJob?.cancel()
+        // Abort the socket read — cancelling the Job alone leaves the blocking
+        // read loop running (and the file growing) until the transfer finishes.
+        downloadCall?.cancel()
         currentDownloadId?.let { id ->
             downloadManager.updateDownloadStateExternal(id, DownloadState(
                 audiobookId = id,
@@ -352,7 +387,10 @@ class DownloadService : Service() {
     }
 
     override fun onDestroy() {
-        downloadJob?.cancel()
+        downloadCall?.cancel()
+        // Cancel the whole scope, not just the active job — otherwise coroutines
+        // launched here outlive the service.
+        serviceScope.cancel()
         super.onDestroy()
     }
 }

--- a/app/src/test/java/com/sappho/audiobooks/data/remote/TokenAuthenticatorTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/data/remote/TokenAuthenticatorTest.kt
@@ -6,11 +6,14 @@ import com.sappho.audiobooks.data.repository.AuthRepository
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import java.io.IOException
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import org.junit.After
+import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
 import retrofit2.Retrofit
@@ -116,6 +119,67 @@ class TokenAuthenticatorTest {
         assertThat(response.code).isEqualTo(401)
         verify { authRepository.clearToken() }
         verify(exactly = 0) { authRepository.saveTokens(any(), any()) }
+
+        response.close()
+    }
+
+    @Test
+    fun `keeps tokens and fails call when refresh returns transient 5xx`() {
+        // Given
+        every { authRepository.getTokenSync() } returns "stale-access"
+        every { authRepository.getRefreshTokenSync() } returns "stored-refresh"
+
+        // 401 for the protected call, 500 from the refresh endpoint (server restarting)
+        mockWebServer.enqueue(MockResponse().setResponseCode(401))
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        // When - the authenticator throws IOException so the call fails as a network error
+        val thrown = assertThrows(IOException::class.java) {
+            client.newCall(protectedRequest()).execute()
+        }
+
+        // Then - credentials survive for a later retry; no 401 surfaced to trigger logout
+        assertThat(thrown.message).contains("transiently")
+        verify(exactly = 0) { authRepository.clearToken() }
+        verify(exactly = 0) { authRepository.saveTokens(any(), any()) }
+    }
+
+    @Test
+    fun `keeps tokens and fails call when refresh request fails on the network`() {
+        // Given
+        every { authRepository.getTokenSync() } returns "stale-access"
+        every { authRepository.getRefreshTokenSync() } returns "stored-refresh"
+
+        // 401 for the protected call, then the server drops the refresh connection
+        mockWebServer.enqueue(MockResponse().setResponseCode(401))
+        mockWebServer.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+
+        // When
+        assertThrows(IOException::class.java) {
+            client.newCall(protectedRequest()).execute()
+        }
+
+        // Then - a network blip during refresh must never destroy valid credentials
+        verify(exactly = 0) { authRepository.clearToken() }
+        verify(exactly = 0) { authRepository.saveTokens(any(), any()) }
+    }
+
+    @Test
+    fun `clears tokens when refresh is rejected with 403`() {
+        // Given
+        every { authRepository.getTokenSync() } returns "stale-access"
+        every { authRepository.getRefreshTokenSync() } returns "stored-refresh"
+
+        // 401 for the protected call, 403 from the refresh endpoint (token revoked)
+        mockWebServer.enqueue(MockResponse().setResponseCode(401))
+        mockWebServer.enqueue(MockResponse().setResponseCode(403))
+
+        // When
+        val response = client.newCall(protectedRequest()).execute()
+
+        // Then - definitive rejection clears tokens and lets the 401 drive logout
+        assertThat(response.code).isEqualTo(401)
+        verify { authRepository.clearToken() }
 
         response.close()
     }


### PR DESCRIPTION
## Summary

First of three PRs landing the deep-audit fixes. This one covers all critical and high-severity issues in the playback/download/auth services.

- **C1 — Token leak in logs**: `AudioPlaybackService` logged the full streaming URL, which carries the auth token as a query parameter. Now logs only the audiobook ID.
- **C2 — Spurious logout on server blip**: `TokenAuthenticator` cleared tokens on *any* refresh failure, so a 500/timeout during token refresh logged the user out. Now tokens are cleared only on a definitive 401/403 refresh rejection; transient failures throw `IOException` so the call fails as a network error and the final 401 never reaches the logout-trigger interceptor.
- **C3 — Download cancellation didn't work**: coroutine `Job.cancel()` doesn't interrupt OkHttp's blocking `InputStream.read`. `DownloadService` now tracks the `Call` and cancels it explicitly, checks `ensureActive()` per chunk, uses `use{}` for stream cleanup, cleans up partial files quietly on cancellation, and cancels any prior download before starting a new one.
- **H1 — ANR risk**: `runBlocking` progress sync in `onTaskRemoved`/`onDestroy` replaced with `saveOfflineProgress` + `ProgressSyncWorker` handoff (WorkManager, with server-position conflict check).
- **H2 — Coroutine leaks**: both services now cancel `serviceScope` in `onDestroy` (individual job cancels missed `sleepTimerJob` and the fallback coroutine).
- **H4 — No auto-resume after focus loss**: playback now resumes after transient audio focus loss (e.g. navigation prompt) via a `pausedByTransientFocusLoss` flag.

## Tests

- 3 new `TokenAuthenticatorTest` cases: refresh 5xx keeps tokens + throws `IOException`; refresh network failure keeps tokens; refresh 403 clears tokens.
- `./gradlew testDebugUnitTest`: **182/182 pass** (baseline 179 + 3 new).

## Version

versionCode 102, versionName 0.9.84

🤖 Generated with [Claude Code](https://claude.com/claude-code)