### PR TITLE
fix: coroutine cancellation sweep + medium audit fixes (0.9.85)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 102
-        versionName = "0.9.84"
+        versionCode = 103
+        versionName = "0.9.85"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/sappho/audiobooks/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/repository/AuthRepository.kt
@@ -203,16 +203,36 @@ class AuthRepository @Inject constructor(
     }
 
     private fun createEncryptedPrefs(): SharedPreferences {
-        return try {
-            EncryptedSharedPreferences.create(
-                context,
-                PREFS_NAME,
-                masterKey,
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            )
-        } catch (e: Exception) {
-            Log.e("AuthRepository", "Failed to decrypt preferences, clearing corrupted data", e)
+        // Android Keystore is known to throw transient errors (e.g. right after
+        // device unlock or an OS update). Retry before falling back to the
+        // destructive wipe below — wiping on a transient failure permanently
+        // destroys valid tokens and forces a re-login. Retries are immediate
+        // (no sleep): this runs during Hilt singleton construction on the main
+        // thread, so any delay here is startup jank, and transient Keystore
+        // errors usually clear on the very next attempt.
+        var lastError: Exception? = null
+        repeat(CREATE_PREFS_MAX_ATTEMPTS) { attempt ->
+            try {
+                return EncryptedSharedPreferences.create(
+                    context,
+                    PREFS_NAME,
+                    masterKey,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+                )
+            } catch (e: Exception) {
+                lastError = e
+                Log.w(
+                    "AuthRepository",
+                    "EncryptedSharedPreferences creation failed (attempt ${attempt + 1}/$CREATE_PREFS_MAX_ATTEMPTS)",
+                    e
+                )
+            }
+        }
+
+        // Repeated failures — treat as true corruption and recreate from scratch.
+        Log.e("AuthRepository", "Failed to open encrypted preferences after retries, clearing corrupted data", lastError)
+        return run {
             clearCorruptedData()
             // Create new master key and prefs after clearing
             val newMasterKey = MasterKey.Builder(context)
@@ -264,6 +284,7 @@ class AuthRepository @Inject constructor(
 
     companion object {
         private const val PREFS_NAME = "secure_prefs"
+        private const val CREATE_PREFS_MAX_ATTEMPTS = 3
         private const val KEY_TOKEN = "auth_token"
         private const val KEY_REFRESH_TOKEN = "refresh_token"
         private const val KEY_SERVER_URL = "server_url"

--- a/app/src/main/java/com/sappho/audiobooks/data/update/InAppUpdateManager.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/update/InAppUpdateManager.kt
@@ -3,6 +3,8 @@ package com.sappho.audiobooks.data.update
 import android.app.Activity
 import android.content.Context
 import android.util.Log
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
 import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.AppUpdateManager
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
@@ -117,7 +119,13 @@ class InAppUpdateManager @Inject constructor(
         }
     }
 
-    fun startUpdate(activity: Activity) {
+    /**
+     * Launches the Play update flow via the ActivityResult API. The old
+     * request-code overload of startUpdateFlowForResult is deprecated and its
+     * result was never delivered anywhere (MainActivity has no
+     * onActivityResult), so declined updates left the state stuck on Downloading.
+     */
+    fun startUpdate(launcher: ActivityResultLauncher<IntentSenderRequest>) {
         val info = appUpdateInfo ?: run {
             Log.w(TAG, "No update info available")
             return
@@ -146,13 +154,24 @@ class InAppUpdateManager @Inject constructor(
 
             appUpdateManager.startUpdateFlowForResult(
                 info,
-                activity,
-                AppUpdateOptions.defaultOptions(updateType),
-                UPDATE_REQUEST_CODE
+                launcher,
+                AppUpdateOptions.defaultOptions(updateType)
             )
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start update flow", e)
             _updateState.value = UpdateState.Failed("Failed to start update: ${e.message}")
+        }
+    }
+
+    /**
+     * Called with the result of the update-flow dialog. Anything other than
+     * RESULT_OK means the user declined or the flow failed — reset the state so
+     * the UI is not stuck on a Downloading dialog.
+     */
+    fun onUpdateFlowResult(resultCode: Int) {
+        if (resultCode != Activity.RESULT_OK) {
+            Log.d(TAG, "Update flow not accepted (resultCode=$resultCode)")
+            _updateState.value = UpdateState.None
         }
     }
 
@@ -173,6 +192,5 @@ class InAppUpdateManager @Inject constructor(
 
     companion object {
         private const val TAG = "InAppUpdateManager"
-        const val UPDATE_REQUEST_CODE = 1001
     }
 }

--- a/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
+++ b/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
@@ -31,6 +31,41 @@ object NetworkModule {
 
     private const val DEFAULT_BASE_URL = "http://192.168.1.100:3002"
 
+    /**
+     * True for hosts on a private/local network where the dynamic-URL rewrite
+     * and auth header should apply. Covers loopback plus all three RFC-1918
+     * blocks — including 172.16.0.0/12 (second octet 16-31), which is common
+     * for Docker and corporate networks.
+     */
+    internal fun isPrivateNetworkHost(host: String): Boolean {
+        if (host == "localhost" || host == "127.0.0.1") return true
+        if (host.startsWith("192.168.") || host.startsWith("10.")) return true
+        if (host.startsWith("172.")) {
+            val secondOctet = host.split(".").getOrNull(1)?.toIntOrNull()
+            return secondOctet != null && secondOctet in 16..31
+        }
+        return false
+    }
+
+    /**
+     * Sanitizes a stored server URL to scheme+host+port for use as Retrofit's
+     * static baseUrl. Retrofit throws IllegalArgumentException at DI-graph
+     * creation for base URLs with a path that doesn't end in "/" (e.g.
+     * "https://host/sappho" as stored, since AuthRepository trims the trailing
+     * slash) — which would crash the app at startup with no recovery path.
+     * Dropping the path is safe because the serverUrlInterceptor rewrites every
+     * request URL from the stored value anyway.
+     */
+    internal fun sanitizeBaseUrl(url: String?): String {
+        val httpUrl = url?.toHttpUrlOrNull() ?: return "$DEFAULT_BASE_URL/"
+        return okhttp3.HttpUrl.Builder()
+            .scheme(httpUrl.scheme)
+            .host(httpUrl.host)
+            .port(httpUrl.port)
+            .build()
+            .toString()
+    }
+
     @Provides
     @Singleton
     fun provideGson(): Gson {
@@ -98,10 +133,7 @@ object NetworkModule {
         // External URLs should be passed through unchanged without auth headers
         val isExternalUrl = serverHost != null &&
             originalHost != serverHost &&
-            originalHost != "localhost" &&
-            !originalHost.startsWith("192.168.") &&
-            !originalHost.startsWith("10.") &&
-            originalHost != "127.0.0.1"
+            !isPrivateNetworkHost(originalHost)
 
         if (isExternalUrl) {
             // External URL - pass through unchanged (no auth, no URL rewriting)
@@ -206,9 +238,8 @@ object NetworkModule {
         gson: Gson,
         authRepository: AuthRepository
     ): SapphoApi {
-        val baseUrl = authRepository.getServerUrlSync() ?: DEFAULT_BASE_URL
         return Retrofit.Builder()
-            .baseUrl(baseUrl)
+            .baseUrl(sanitizeBaseUrl(authRepository.getServerUrlSync()))
             .client(client)
             .addConverterFactory(GsonConverterFactory.create(gson))
             .build()
@@ -233,11 +264,10 @@ object NetworkModule {
         @ApplicationContext context: Context,
         authRepository: AuthRepository
     ): Retrofit {
-        // Get base URL from auth repository (where server URL is stored)
-        val baseUrl = authRepository.getServerUrlSync() ?: DEFAULT_BASE_URL
-
+        // Base URL is only a Retrofit constructor requirement — the
+        // serverUrlInterceptor rewrites every request to the stored server URL.
         return Retrofit.Builder()
-            .baseUrl(baseUrl)
+            .baseUrl(sanitizeBaseUrl(authRepository.getServerUrlSync()))
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create(gson))
             .build()

--- a/app/src/main/java/com/sappho/audiobooks/download/DownloadManager.kt
+++ b/app/src/main/java/com/sappho/audiobooks/download/DownloadManager.kt
@@ -5,9 +5,11 @@ import android.util.Log
 import com.sappho.audiobooks.data.repository.AuthRepository
 import com.sappho.audiobooks.domain.model.Audiobook
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -72,6 +74,12 @@ class DownloadManager @Inject constructor(
     private val _pendingProgress = MutableStateFlow<Map<Int, PendingProgress>>(emptyMap())
     val pendingProgress: StateFlow<Map<Int, PendingProgress>> = _pendingProgress
 
+    // Serialize JSON metadata file writes: DownloadService and this class can
+    // both trigger saves concurrently, and unsynchronized writes could leave
+    // the file with stale (or interleaved) content.
+    private val metadataFileLock = Any()
+    private val pendingProgressFileLock = Any()
+
     init {
         loadDownloadedBooks()
         loadPendingProgress()
@@ -125,20 +133,26 @@ class DownloadManager @Inject constructor(
     )
 
     private fun saveDownloadedBooks() {
-        try {
-            val gson = com.google.gson.Gson()
-            val jsonBooks = _downloadedBooks.value.map { book ->
-                DownloadedBookJson(
-                    audiobook = book.audiobook,
-                    filePath = book.filePath,
-                    fileSize = book.fileSize,
-                    downloadedAt = book.downloadedAt,
-                    chapters = book.chapters
-                )
+        // The lock serializes file writes; the snapshot is read INSIDE it so a
+        // later write always persists state at least as fresh as any earlier
+        // one. A mutation landing mid-write is fine — every mutation calls
+        // save() itself, so the file converges to the latest state.
+        synchronized(metadataFileLock) {
+            try {
+                val gson = com.google.gson.Gson()
+                val jsonBooks = _downloadedBooks.value.map { book ->
+                    DownloadedBookJson(
+                        audiobook = book.audiobook,
+                        filePath = book.filePath,
+                        fileSize = book.fileSize,
+                        downloadedAt = book.downloadedAt,
+                        chapters = book.chapters
+                    )
+                }
+                metadataFile.writeText(gson.toJson(jsonBooks))
+            } catch (e: Exception) {
+                Log.e(TAG, "Error saving downloaded books", e)
             }
-            metadataFile.writeText(gson.toJson(jsonBooks))
-        } catch (e: Exception) {
-            Log.e(TAG, "Error saving downloaded books", e)
         }
     }
 
@@ -196,6 +210,10 @@ class DownloadManager @Inject constructor(
                         val buffer = ByteArray(8192)
                         var bytesRead: Int
                         var totalBytesRead = 0L
+                        // Throttle progress emissions to whole-percent steps:
+                        // emitting per 8KB chunk floods the StateFlow with tens of
+                        // thousands of updates and forces needless recompositions.
+                        var lastReportedPercent = -1
 
                         while (inputStream.read(buffer).also { bytesRead = it } != -1) {
                             outputStream.write(buffer, 0, bytesRead)
@@ -207,12 +225,16 @@ class DownloadManager @Inject constructor(
                                 0f
                             }
 
-                            updateDownloadState(audiobookId, DownloadState(
-                                audiobookId = audiobookId,
-                                progress = progress,
-                                isDownloading = true,
-                                isCompleted = false
-                            ))
+                            val percent = (progress * 100).toInt()
+                            if (percent != lastReportedPercent) {
+                                lastReportedPercent = percent
+                                updateDownloadState(audiobookId, DownloadState(
+                                    audiobookId = audiobookId,
+                                    progress = progress,
+                                    isDownloading = true,
+                                    isCompleted = false
+                                ))
+                            }
                         }
                     }
                 }
@@ -225,6 +247,10 @@ class DownloadManager @Inject constructor(
                     } else {
                         emptyList()
                     }
+                } catch (e: CancellationException) {
+                    // Never swallow cancellation - it must propagate so the
+                    // coroutine actually stops.
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to fetch chapters for download", e)
                     emptyList()
@@ -239,7 +265,7 @@ class DownloadManager @Inject constructor(
                     chapters = chapters
                 )
 
-                _downloadedBooks.value = _downloadedBooks.value + downloadedBook
+                _downloadedBooks.update { it + downloadedBook }
                 saveDownloadedBooks()
 
                 // Update state to completed
@@ -252,6 +278,15 @@ class DownloadManager @Inject constructor(
 
                 Log.d(TAG, "Download complete: ${file.absolutePath}")
                 true
+            } catch (e: CancellationException) {
+                // Reset UI state, then rethrow so cancellation propagates.
+                updateDownloadState(audiobookId, DownloadState(
+                    audiobookId = audiobookId,
+                    progress = 0f,
+                    isDownloading = false,
+                    isCompleted = false
+                ))
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Download failed", e)
                 updateDownloadState(audiobookId, DownloadState(
@@ -275,13 +310,11 @@ class DownloadManager @Inject constructor(
                 file.delete()
             }
 
-            _downloadedBooks.value = _downloadedBooks.value.filter { it.audiobook.id != audiobookId }
+            _downloadedBooks.update { books -> books.filter { it.audiobook.id != audiobookId } }
             saveDownloadedBooks()
 
             // Clear download state
-            val currentStates = _downloadStates.value.toMutableMap()
-            currentStates.remove(audiobookId)
-            _downloadStates.value = currentStates
+            _downloadStates.update { it - audiobookId }
 
             true
         } catch (e: Exception) {
@@ -291,9 +324,10 @@ class DownloadManager @Inject constructor(
     }
 
     private fun updateDownloadState(audiobookId: Int, state: DownloadState) {
-        val currentStates = _downloadStates.value.toMutableMap()
-        currentStates[audiobookId] = state
-        _downloadStates.value = currentStates
+        // update {} makes the read-modify-write atomic: concurrent downloads
+        // (or DownloadService callbacks) would otherwise lose entries when two
+        // threads snapshot the same map.
+        _downloadStates.update { it + (audiobookId to state) }
     }
 
     // Called by DownloadService to update state
@@ -315,33 +349,31 @@ class DownloadManager @Inject constructor(
             downloadedAt = System.currentTimeMillis(),
             chapters = chapters
         )
-        _downloadedBooks.value = _downloadedBooks.value + downloadedBook
+        _downloadedBooks.update { it + downloadedBook }
         saveDownloadedBooks()
     }
 
     fun clearDownloadError(audiobookId: Int) {
-        val currentStates = _downloadStates.value.toMutableMap()
-        val currentState = currentStates[audiobookId]
-        if (currentState?.error != null) {
-            // Clear the error but keep other state if still relevant
-            currentStates[audiobookId] = currentState.copy(error = null)
-            _downloadStates.value = currentStates
+        _downloadStates.update { states ->
+            val currentState = states[audiobookId]
+            if (currentState?.error != null) {
+                // Clear the error but keep other state if still relevant
+                states + (audiobookId to currentState.copy(error = null))
+            } else {
+                states
+            }
         }
     }
 
     fun clearAllDownloadErrors() {
-        val currentStates = _downloadStates.value.toMutableMap()
-        val hasChanges = currentStates.values.any { !it.error.isNullOrBlank() }
-        
-        if (hasChanges) {
-            currentStates.replaceAll { _, state ->
-                if (!state.error.isNullOrBlank()) {
-                    state.copy(error = null)
-                } else {
-                    state
+        _downloadStates.update { states ->
+            if (states.values.any { !it.error.isNullOrBlank() }) {
+                states.mapValues { (_, state) ->
+                    if (!state.error.isNullOrBlank()) state.copy(error = null) else state
                 }
+            } else {
+                states
             }
-            _downloadStates.value = currentStates
         }
     }
 
@@ -361,12 +393,14 @@ class DownloadManager @Inject constructor(
     }
 
     private fun savePendingProgress() {
-        try {
-            val gson = com.google.gson.Gson()
-            val progressList = _pendingProgress.value.values.toList()
-            pendingProgressFile.writeText(gson.toJson(progressList))
-        } catch (e: Exception) {
-            Log.e(TAG, "Error saving pending progress", e)
+        synchronized(pendingProgressFileLock) {
+            try {
+                val gson = com.google.gson.Gson()
+                val progressList = _pendingProgress.value.values.toList()
+                pendingProgressFile.writeText(gson.toJson(progressList))
+            } catch (e: Exception) {
+                Log.e(TAG, "Error saving pending progress", e)
+            }
         }
     }
 
@@ -377,9 +411,7 @@ class DownloadManager @Inject constructor(
             position = position,
             timestamp = System.currentTimeMillis()
         )
-        val current = _pendingProgress.value.toMutableMap()
-        current[audiobookId] = pending
-        _pendingProgress.value = current
+        _pendingProgress.update { it + (audiobookId to pending) }
         savePendingProgress()
 
         // Also update the audiobook's progress in the downloaded book metadata
@@ -395,9 +427,7 @@ class DownloadManager @Inject constructor(
 
     fun clearPendingProgress(audiobookId: Int) {
         Log.d(TAG, "Clearing pending progress for book $audiobookId")
-        val current = _pendingProgress.value.toMutableMap()
-        current.remove(audiobookId)
-        _pendingProgress.value = current
+        _pendingProgress.update { it - audiobookId }
         savePendingProgress()
     }
 
@@ -426,19 +456,21 @@ class DownloadManager @Inject constructor(
     }
 
     private fun updateDownloadedBookProgress(audiobookId: Int, position: Int) {
-        val currentBooks = _downloadedBooks.value.toMutableList()
-        val index = currentBooks.indexOfFirst { it.audiobook.id == audiobookId }
-        if (index >= 0) {
-            val book = currentBooks[index]
-            val updatedProgress = book.audiobook.progress?.copy(position = position)
-                ?: com.sappho.audiobooks.domain.model.Progress(
-                    position = position,
-                    completed = 0
-                )
-            val updatedAudiobook = book.audiobook.copy(progress = updatedProgress)
-            currentBooks[index] = book.copy(audiobook = updatedAudiobook)
-            _downloadedBooks.value = currentBooks
-            saveDownloadedBooks()
+        if (_downloadedBooks.value.none { it.audiobook.id == audiobookId }) return
+        _downloadedBooks.update { books ->
+            books.map { book ->
+                if (book.audiobook.id == audiobookId) {
+                    val updatedProgress = book.audiobook.progress?.copy(position = position)
+                        ?: com.sappho.audiobooks.domain.model.Progress(
+                            position = position,
+                            completed = 0
+                        )
+                    book.copy(audiobook = book.audiobook.copy(progress = updatedProgress))
+                } else {
+                    book
+                }
+            }
         }
+        saveDownloadedBooks()
     }
 }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/MainActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/MainActivity.kt
@@ -3,6 +3,7 @@ package com.sappho.audiobooks.presentation
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,14 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var inAppUpdateManager: InAppUpdateManager
+
+    // ActivityResult launcher for the Play in-app update flow. Replaces the
+    // deprecated request-code overload, whose result was silently dropped.
+    private val updateResultLauncher = registerForActivityResult(
+        ActivityResultContracts.StartIntentSenderForResult()
+    ) { result ->
+        inAppUpdateManager.onUpdateFlowResult(result.resultCode)
+    }
 
     override fun onResume() {
         super.onResume()
@@ -69,7 +78,7 @@ class MainActivity : ComponentActivity() {
                         is UpdateState.Available -> {
                             UpdateAvailableDialog(
                                 onUpdateClick = {
-                                    inAppUpdateManager.startUpdate(this@MainActivity)
+                                    inAppUpdateManager.startUpdate(updateResultLauncher)
                                 },
                                 onDismiss = {
                                     inAppUpdateManager.dismissUpdate()
@@ -94,7 +103,7 @@ class MainActivity : ComponentActivity() {
                                 message = state.message,
                                 onRetryClick = {
                                     inAppUpdateManager.clearError()
-                                    inAppUpdateManager.startUpdate(this@MainActivity)
+                                    inAppUpdateManager.startUpdate(updateResultLauncher)
                                 },
                                 onDismiss = {
                                     inAppUpdateManager.clearError()

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModel.kt
@@ -32,6 +32,7 @@ import com.sappho.audiobooks.util.NetworkMonitor
 import com.sappho.audiobooks.domain.model.ConversionJob
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -244,6 +245,8 @@ class AudiobookDetailViewModel @Inject constructor(
                         _userReviewText.value = userRatingData?.review ?: ""
                         _currentUserId.value = userRatingData?.userId
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     // Rating is optional, don't show error to user
                     Log.e(TAG, "Failed to load rating", e)
@@ -255,6 +258,8 @@ class AudiobookDetailViewModel @Inject constructor(
                     if (avgResponse.isSuccessful) {
                         _averageRating.value = avgResponse.body()
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to load average rating", e)
                 }
@@ -268,6 +273,8 @@ class AudiobookDetailViewModel @Inject constructor(
                     if (progressResponse.isSuccessful) {
                         _progress.value = progressResponse.body()
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     // If progress endpoint fails, check for pending progress
                     val pendingProgress = downloadManager.pendingProgress.value[id]
@@ -287,6 +294,8 @@ class AudiobookDetailViewModel @Inject constructor(
                     if (chaptersResponse.isSuccessful) {
                         _chapters.value = chaptersResponse.body() ?: emptyList()
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to load chapters", e)
                 }
@@ -297,9 +306,13 @@ class AudiobookDetailViewModel @Inject constructor(
                     if (filesResponse.isSuccessful) {
                         _files.value = filesResponse.body() ?: emptyList()
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to load files", e)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 // Network error - fall back to the downloaded data seeded above
                 // (if any), refreshing pending progress in case it changed.
@@ -331,6 +344,8 @@ class AudiobookDetailViewModel @Inject constructor(
                 try {
                     api.markFinished(book.id, com.sappho.audiobooks.data.remote.ProgressUpdateRequest(0, 1, "stopped"))
                     loadAudiobook(book.id) // Reload to get updated progress
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to mark book as finished", e)
                 }
@@ -344,6 +359,8 @@ class AudiobookDetailViewModel @Inject constructor(
                 try {
                     api.clearProgress(book.id)
                     loadAudiobook(book.id) // Reload to get updated progress
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to clear progress", e)
                 }
@@ -359,6 +376,8 @@ class AudiobookDetailViewModel @Inject constructor(
                     if (response.isSuccessful) {
                         onDeleted()
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to delete audiobook", e)
                 }
@@ -390,6 +409,8 @@ class AudiobookDetailViewModel @Inject constructor(
                     } else {
                         _refreshMetadataResult.value = "Failed to refresh metadata"
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     _refreshMetadataResult.value = e.message ?: "Error refreshing metadata"
                 } finally {
@@ -453,6 +474,8 @@ class AudiobookDetailViewModel @Inject constructor(
                         _convertResult.value = "Failed to convert: ${errorMessage ?: "Unknown error"}"
                         _isConverting.value = false
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     _convertResult.value = e.message ?: "Error converting to M4B"
                     _isConverting.value = false
@@ -486,6 +509,8 @@ class AudiobookDetailViewModel @Inject constructor(
                             break
                         }
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     // Network error during poll — keep trying
                     Log.w(TAG, "Conversion poll failed: ${e.message}")
@@ -521,6 +546,8 @@ class AudiobookDetailViewModel @Inject constructor(
             try {
                 api.cancelConversionJob(jobId)
                 // Polling will pick up the cancelled status
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _convertResult.value = "Failed to cancel: ${e.message}"
             }
@@ -546,6 +573,8 @@ class AudiobookDetailViewModel @Inject constructor(
                         startConversionPolling(audiobookId)
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 // Not critical — just means we won't show existing progress
             }
@@ -582,6 +611,8 @@ class AudiobookDetailViewModel @Inject constructor(
                             _isFavorite.value = result.isFavorite
                         }
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to toggle favorite", e)
                 } finally {
@@ -608,12 +639,16 @@ class AudiobookDetailViewModel @Inject constructor(
                             if (avgResponse.isSuccessful) {
                                 _averageRating.value = avgResponse.body()
                             }
+                        } catch (e: CancellationException) {
+                            throw e
                         } catch (e: Exception) {
                             Log.e(TAG, "Failed to refresh average rating", e)
                         }
                         // Refresh reviews list
                         loadReviews(book.id)
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to set rating", e)
                 } finally {
@@ -633,6 +668,8 @@ class AudiobookDetailViewModel @Inject constructor(
             if (response.isSuccessful) {
                 _reviews.value = response.body() ?: emptyList()
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Failed to load reviews", e)
         }
@@ -653,10 +690,14 @@ class AudiobookDetailViewModel @Inject constructor(
                             if (avgResponse.isSuccessful) {
                                 _averageRating.value = avgResponse.body()
                             }
+                        } catch (e: CancellationException) {
+                            throw e
                         } catch (e: Exception) {
                             Log.e(TAG, "Failed to refresh average rating after clear", e)
                         }
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to clear rating", e)
                 } finally {
@@ -684,6 +725,8 @@ class AudiobookDetailViewModel @Inject constructor(
                     } else {
                         _metadataSaveResult.value = "Failed to save metadata: ${response.code()}"
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     _metadataSaveResult.value = "Error: ${e.message}"
                 } finally {
@@ -719,6 +762,8 @@ class AudiobookDetailViewModel @Inject constructor(
                     } else {
                         _metadataSearchError.value = "Search failed: ${response.code()}"
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     _metadataSearchError.value = "Error: ${e.message}"
                 } finally {
@@ -764,6 +809,8 @@ class AudiobookDetailViewModel @Inject constructor(
                             else -> "Failed to embed: ${response.code()} ${errorMessage ?: ""}"
                         }
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     _embedMetadataResult.value = "Error: ${e.message}"
                 } finally {
@@ -793,6 +840,8 @@ class AudiobookDetailViewModel @Inject constructor(
                     } else {
                         _chapterSaveResult.value = "Failed to update chapters: ${response.code()}"
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     _chapterSaveResult.value = "Error: ${e.message}"
                 } finally {
@@ -822,6 +871,8 @@ class AudiobookDetailViewModel @Inject constructor(
                             else -> "Failed to fetch chapters: ${response.code()}"
                         }
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     _fetchChaptersResult.value = "Error: ${e.message}"
                 } finally {
@@ -856,6 +907,8 @@ class AudiobookDetailViewModel @Inject constructor(
                         .map { it.id }
                         .toSet()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to load collections for book", e)
             } finally {
@@ -879,6 +932,8 @@ class AudiobookDetailViewModel @Inject constructor(
                         _bookCollections.value = _bookCollections.value + collectionId
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to toggle book in collection", e)
             }
@@ -900,6 +955,8 @@ class AudiobookDetailViewModel @Inject constructor(
                         }
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to create collection and add book", e)
             }
@@ -926,6 +983,8 @@ class AudiobookDetailViewModel @Inject constructor(
                         if (filesResponse.isSuccessful) {
                             _files.value = filesResponse.body() ?: emptyList()
                         }
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         // File was deleted, but refresh failed - still ok
                     }
@@ -939,6 +998,8 @@ class AudiobookDetailViewModel @Inject constructor(
                     }
                     _deleteFileError.value = errorMessage ?: "Failed to delete file"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _deleteFileError.value = e.message ?: "Error deleting file"
             } finally {
@@ -958,6 +1019,8 @@ class AudiobookDetailViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _isAiConfigured.value = response.body()?.configured ?: false
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _isAiConfigured.value = false
             }
@@ -984,6 +1047,8 @@ class AudiobookDetailViewModel @Inject constructor(
                         }
                         _recapError.value = errorMessage ?: "Failed to load recap"
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     _recapError.value = e.message ?: "Error loading recap"
                 } finally {
@@ -999,6 +1064,8 @@ class AudiobookDetailViewModel @Inject constructor(
                 try {
                     api.clearAudiobookRecap(book.id)
                     _recap.value = null
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to clear recap", e)
                 }
@@ -1018,6 +1085,8 @@ class AudiobookDetailViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _previousBookCompleted.value = response.body()?.previousBookCompleted ?: false
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _previousBookCompleted.value = false
             }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
@@ -77,8 +77,8 @@ fun HomeScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val serverUrl by viewModel.serverUrl.collectAsState()
     val isOffline by viewModel.isOffline.collectAsState()
-    val downloadedBooks by viewModel.downloadManager.downloadedBooks.collectAsState()
-    val downloadStates by viewModel.downloadManager.downloadStates.collectAsState()
+    val downloadedBooks by viewModel.downloadedBooks.collectAsState()
+    val downloadStates by viewModel.downloadStates.collectAsState()
     val syncStatus by viewModel.syncStatus.collectAsState()
 
     // Collections state
@@ -595,13 +595,13 @@ fun SyncStatusBanner(
         Icon(
             imageVector = when {
                 syncStatus.errorMessage != null -> Icons.Default.SyncProblem
-                syncStatus.issyncing -> Icons.Default.Sync
+                syncStatus.isSyncing -> Icons.Default.Sync
                 syncStatus.pendingCount > 0 -> Icons.Default.Sync
                 else -> Icons.Default.CheckCircle
             },
             contentDescription = when {
                 syncStatus.errorMessage != null -> SapphoAccessibility.ContentDescriptions.SYNC_ERROR
-                syncStatus.issyncing -> SapphoAccessibility.ContentDescriptions.SYNC_IN_PROGRESS
+                syncStatus.isSyncing -> SapphoAccessibility.ContentDescriptions.SYNC_IN_PROGRESS
                 syncStatus.pendingCount > 0 -> SapphoAccessibility.ContentDescriptions.SYNC_PENDING
                 else -> SapphoAccessibility.ContentDescriptions.SYNC_COMPLETE
             },
@@ -626,7 +626,7 @@ fun SyncStatusBanner(
                         color = SapphoTextSecondary
                     )
                 }
-                syncStatus.issyncing -> {
+                syncStatus.isSyncing -> {
                     Text(
                         text = "Syncing progress...",
                         style = MaterialTheme.typography.bodyMedium,
@@ -672,7 +672,7 @@ fun SyncStatusBanner(
             Spacer(modifier = Modifier.width(Spacing.XS))
         }
         
-        if (!syncStatus.issyncing && syncStatus.pendingCount > 0) {
+        if (!syncStatus.isSyncing && syncStatus.pendingCount > 0) {
             val syncHaptic = HapticPatterns.buttonPress()
             TextButton(
                 onClick = { 

--- a/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeViewModel.kt
@@ -28,7 +28,7 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val api: SapphoApi,
     private val authRepository: AuthRepository,
-    val downloadManager: DownloadManager,  // Make public for HomeScreen access
+    private val downloadManager: DownloadManager,
     private val networkMonitor: NetworkMonitor,
     private val syncStatusManager: SyncStatusManager,
     private val performanceMonitor: PerformanceMonitor
@@ -63,6 +63,13 @@ class HomeViewModel @Inject constructor(
     
     // Expose sync status to UI
     val syncStatus: StateFlow<com.sappho.audiobooks.sync.SyncStatus> = syncStatusManager.syncStatus
+
+    // Expose only the download flows the UI needs, not the whole DownloadManager,
+    // so the view can't reach mutating APIs like deleteDownload directly.
+    val downloadedBooks: StateFlow<List<com.sappho.audiobooks.download.DownloadedBook>> =
+        downloadManager.downloadedBooks
+    val downloadStates: StateFlow<Map<Int, com.sappho.audiobooks.download.DownloadState>> =
+        downloadManager.downloadStates
 
     // Collections state
     private val _collections = MutableStateFlow<List<Collection>>(emptyList())
@@ -116,6 +123,8 @@ class HomeViewModel @Inject constructor(
                 // fall back to the offline UI (downloaded books).
                 val reachedServer = try {
                     withTimeoutOrNull(FEED_TIMEOUT_MS) { loadHomeFeed() } ?: false
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to load home data", e)
                     false
@@ -216,6 +225,8 @@ class HomeViewModel @Inject constructor(
                     updateFavoriteStatus(audiobookId, isFavorite)
                     onResult(isFavorite)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to toggle favorite", e)
             }
@@ -285,6 +296,8 @@ class HomeViewModel @Inject constructor(
                         .map { it.id }
                         .toSet()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to load collections for book", e)
             } finally {
@@ -308,6 +321,8 @@ class HomeViewModel @Inject constructor(
                         _bookCollections.value = _bookCollections.value + collectionId
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to toggle book in collection", e)
             }
@@ -328,6 +343,8 @@ class HomeViewModel @Inject constructor(
                         }
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to create collection and add book", e)
             }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginViewModel.kt
@@ -7,6 +7,7 @@ import com.sappho.audiobooks.data.remote.MfaVerifyRequest
 import com.sappho.audiobooks.data.remote.SapphoApi
 import com.sappho.audiobooks.data.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -85,6 +86,8 @@ class LoginViewModel @Inject constructor(
                     }
                     _uiState.value = LoginUiState.Error(errorMessage)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 val errorMessage = when (e) {
                     is java.net.UnknownHostException -> "Cannot reach server. Please check your server URL and network connection"
@@ -135,6 +138,8 @@ class LoginViewModel @Inject constructor(
                         _uiState.value = LoginUiState.MfaError(mfaToken, errorMessage)
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _uiState.value = LoginUiState.MfaError(mfaToken, "Network error: ${e.message}")
             }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
@@ -186,6 +186,7 @@ fun PlayerScreen(
     val playbackSpeed = playerState?.playbackSpeed?.collectAsState()?.value ?: 1.0f
     val sleepTimerRemaining = playerState?.sleepTimerRemaining?.collectAsState()?.value
     val sleepAtEndOfChapter = playerState?.sleepAtEndOfChapter?.collectAsState()?.value ?: false
+    val playbackError = playerState?.playbackError?.collectAsState()?.value
 
     // When casting, poll the Cast position periodically
     var castPosition by remember { mutableLongStateOf(0L) }
@@ -350,6 +351,34 @@ fun PlayerScreen(
                         },
                         confirmButton = {
                             TextButton(onClick = { castManager.clearError() }) {
+                                Text("OK", color = SapphoInfo)
+                            }
+                        },
+                        containerColor = SapphoSurfaceLight,
+                        shape = androidx.compose.foundation.shape.RoundedCornerShape(16.dp)
+                    )
+                }
+
+                // Playback error dialog — surfaced from AudioPlaybackService via
+                // PlayerState so the user can acknowledge the failure.
+                playbackError?.let { error ->
+                    AlertDialog(
+                        onDismissRequest = { playerState?.clearPlaybackError() },
+                        title = {
+                            Text(
+                                "Playback Error",
+                                color = Color.White,
+                                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
+                            )
+                        },
+                        text = {
+                            Text(
+                                error,
+                                color = SapphoIconDefault
+                            )
+                        },
+                        confirmButton = {
+                            TextButton(onClick = { playerState?.clearPlaybackError() }) {
                                 Text("OK", color = SapphoInfo)
                             }
                         },

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerViewModel.kt
@@ -15,6 +15,7 @@ import com.sappho.audiobooks.service.PlayerState
 import com.sappho.audiobooks.cast.CastHelper
 import com.sappho.audiobooks.cast.CastManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -69,6 +70,8 @@ class PlayerViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     book = response.body()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
             }
 
@@ -93,6 +96,8 @@ class PlayerViewModel @Inject constructor(
                             actualStartPosition = progress.position
                         }
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (_: Exception) {
                 }
             }
@@ -151,6 +156,8 @@ class PlayerViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     book = response.body()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
             }
 
@@ -204,6 +211,8 @@ class PlayerViewModel @Inject constructor(
                 if (kotlin.math.abs(serverPosition - localPosition) > 2) {
                     service.seekTo(serverPosition)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Exception) {
                 // Network failure — keep showing current state
             }
@@ -245,6 +254,8 @@ class PlayerViewModel @Inject constructor(
                         bestPosition = progress.position
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Exception) {
                 // Network failed — use local position
             }
@@ -269,6 +280,9 @@ class PlayerViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _listeningSessions.value = response.body()?.sessions ?: emptyList()
                 }
+            } catch (e: CancellationException) {
+                _historyLoading.value = false
+                throw e
             } catch (_: Exception) { }
             _historyLoading.value = false
         }
@@ -281,6 +295,8 @@ class PlayerViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _chapters.value = response.body() ?: emptyList()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 // Offline - try to load chapters from downloaded data
                 val downloadedBook = downloadManager.getDownloadedBook(audiobookId)

--- a/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
@@ -47,6 +47,7 @@ import com.sappho.audiobooks.presentation.theme.Timing
 import com.sappho.audiobooks.sync.ProgressSyncWorker
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -79,6 +80,10 @@ class AudioPlaybackService : MediaLibraryService() {
     lateinit var userPreferences: UserPreferencesRepository
 
     private var player: ExoPlayer? = null
+    // @Volatile: written from a background coroutine (cover fetch) and read on
+    // the main thread when building notifications — without it the main thread
+    // may never observe the loaded bitmap.
+    @Volatile
     private var currentCoverBitmap: android.graphics.Bitmap? = null
     private var mediaLibrarySession: MediaLibrarySession? = null
     private val serviceScope = CoroutineScope(Dispatchers.Main + Job())
@@ -133,6 +138,15 @@ class AudioPlaybackService : MediaLibraryService() {
         @Volatile
         var instance: AudioPlaybackService? = null
             private set
+
+        /**
+         * Clamps a skip-forward target to the book duration. When the duration
+         * is not yet known (<= 0, e.g. still buffering), the raw target is
+         * returned unclamped — clamping against 0 would seek back to the start.
+         */
+        internal fun clampSkipForwardPosition(targetSeconds: Long, durationSeconds: Long): Long {
+            return if (durationSeconds > 0) targetSeconds.coerceAtMost(durationSeconds) else targetSeconds
+        }
     }
 
     // Cache for audiobooks to avoid re-fetching
@@ -421,12 +435,12 @@ class AudioPlaybackService : MediaLibraryService() {
                     android.util.Log.e("AudioPlaybackService", "Player error: ${error.message}", error)
                     playerState.updateLoadingState(false)
                     playerState.updatePlayingState(false)
-                    // Show a toast to the user
-                    android.widget.Toast.makeText(
-                        this@AudioPlaybackService,
-                        "Playback error: ${error.message ?: "Unknown error"}",
-                        android.widget.Toast.LENGTH_LONG
-                    ).show()
+                    // Surface the error through PlayerState so the UI can show a
+                    // dismissible dialog — a Toast from a service is easy to miss
+                    // and gives the user no way to acknowledge the failure.
+                    playerState.updatePlaybackError(
+                        "Playback error: ${error.message ?: "Unknown error"}"
+                    )
                 }
             })
         }
@@ -695,6 +709,11 @@ class AudioPlaybackService : MediaLibraryService() {
                         } else {
                             future.set(mutableListOf())
                         }
+                    } catch (e: CancellationException) {
+                        // Resolve the future before rethrowing so the Media3
+                        // controller waiting on it does not hang forever.
+                        future.set(mutableListOf())
+                        throw e
                     } catch (e: Exception) {
                         android.util.Log.e("AutoService", "Voice search error", e)
                         future.set(mutableListOf())
@@ -730,6 +749,9 @@ class AudioPlaybackService : MediaLibraryService() {
                             } else {
                                 future.set(mutableListOf())
                             }
+                        } catch (e: CancellationException) {
+                            future.set(mutableListOf())
+                            throw e
                         } catch (e: Exception) {
                             android.util.Log.e("AudioPlaybackService", "Error loading chapter", e)
                             future.set(mutableListOf())
@@ -763,6 +785,9 @@ class AudioPlaybackService : MediaLibraryService() {
                             } else {
                                 future.set(mutableListOf())
                             }
+                        } catch (e: CancellationException) {
+                            future.set(mutableListOf())
+                            throw e
                         } catch (e: Exception) {
                             android.util.Log.e("AudioPlaybackService", "Error loading audiobook for playback", e)
                             future.set(mutableListOf())
@@ -851,6 +876,11 @@ class AudioPlaybackService : MediaLibraryService() {
                     } else {
                         future.setException(Exception("Failed to load audiobooks"))
                     }
+                } catch (e: CancellationException) {
+                    // Resolve the future before rethrowing so the controller
+                    // waiting on it does not hang forever.
+                    future.setException(e)
+                    throw e
                 } catch (e: Exception) {
                     android.util.Log.e("AutoService", "Error in playback resumption", e)
                     future.setException(e)
@@ -895,6 +925,8 @@ class AudioPlaybackService : MediaLibraryService() {
                 android.util.Log.e("AutoService", "Search failed: ${response.code()}")
                 lastSearchResults = emptyList()
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("AutoService", "Exception during search", e)
             lastSearchResults = emptyList()
@@ -924,6 +956,8 @@ class AudioPlaybackService : MediaLibraryService() {
                         android.util.Log.w("AutoService", "Voice search - no results for: $query")
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AutoService", "Voice search error", e)
             }
@@ -1009,6 +1043,9 @@ class AudioPlaybackService : MediaLibraryService() {
                 } else {
                     future.set(LibraryResult.ofItemList(ImmutableList.of(), params))
                 }
+            } catch (e: CancellationException) {
+                future.set(LibraryResult.ofItemList(ImmutableList.of(), params))
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AudioPlaybackService", "Error loading chapters", e)
                 future.set(LibraryResult.ofItemList(ImmutableList.of(), params))
@@ -1067,6 +1104,9 @@ class AudioPlaybackService : MediaLibraryService() {
                     android.util.Log.e("AutoService", "Failed to load in-progress books: ${response.code()}")
                     future.set(LibraryResult.ofItemList(ImmutableList.of(), params))
                 }
+            } catch (e: CancellationException) {
+                future.set(LibraryResult.ofItemList(ImmutableList.of(), params))
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AutoService", "Exception loading in-progress books", e)
                 future.set(LibraryResult.ofItemList(ImmutableList.of(), params))
@@ -1105,6 +1145,9 @@ class AudioPlaybackService : MediaLibraryService() {
                     android.util.Log.e("AutoService", "Failed to load recent books: ${response.code()}")
                     future.set(LibraryResult.ofItemList(ImmutableList.of(), params))
                 }
+            } catch (e: CancellationException) {
+                future.set(LibraryResult.ofItemList(ImmutableList.of(), params))
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AutoService", "Exception loading recent books", e)
                 future.set(LibraryResult.ofItemList(ImmutableList.of(), params))
@@ -1142,6 +1185,9 @@ class AudioPlaybackService : MediaLibraryService() {
                     android.util.Log.e("AutoService", "Failed to load all books: ${response.code()}")
                     future.set(LibraryResult.ofItemList(ImmutableList.of(), params))
                 }
+            } catch (e: CancellationException) {
+                future.set(LibraryResult.ofItemList(ImmutableList.of(), params))
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AutoService", "Exception loading all books", e)
                 future.set(LibraryResult.ofItemList(ImmutableList.of(), params))
@@ -1168,6 +1214,9 @@ class AudioPlaybackService : MediaLibraryService() {
                 } else {
                     future.set(LibraryResult.ofError(SessionError.ERROR_NOT_SUPPORTED))
                 }
+            } catch (e: CancellationException) {
+                future.set(LibraryResult.ofError(SessionError.ERROR_NOT_SUPPORTED))
+                throw e
             } catch (e: Exception) {
                 future.set(LibraryResult.ofError(SessionError.ERROR_NOT_SUPPORTED))
             }
@@ -1405,7 +1454,10 @@ class AudioPlaybackService : MediaLibraryService() {
     fun skipForward() {
         player?.let {
             val skipSeconds = userPreferences.skipForwardSeconds.value.toLong()
-            val newPosition = (it.currentPosition / 1000 + skipSeconds).coerceAtMost(playerState.duration.value)
+            val newPosition = clampSkipForwardPosition(
+                targetSeconds = it.currentPosition / 1000 + skipSeconds,
+                durationSeconds = playerState.duration.value
+            )
             seekTo(newPosition)
         }
     }
@@ -1566,6 +1618,8 @@ class AudioPlaybackService : MediaLibraryService() {
                     )
                     // Successfully synced - clear any pending progress for this book
                     downloadManager.clearPendingProgress(book.id)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     if (!respectDelayGuard || isPlayingLocalFile) {
                         // Pause/stop event or offline — save locally for later sync
@@ -1593,6 +1647,8 @@ class AudioPlaybackService : MediaLibraryService() {
                         )
                     )
                     downloadManager.clearPendingProgress(pending.audiobookId)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (_: Exception) {
                     // Continue trying remaining items
                 }
@@ -1606,6 +1662,8 @@ class AudioPlaybackService : MediaLibraryService() {
                 playerState.currentAudiobook.value?.let { book ->
                     api.markFinished(book.id, ProgressUpdateRequest(0, 1, "stopped"))
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AudioPlaybackService", "Failed to mark audiobook as finished", e)
             }
@@ -1710,6 +1768,8 @@ class AudioPlaybackService : MediaLibraryService() {
                         }
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AudioPlaybackService", "Failed to load cover bitmap", e)
             }

--- a/app/src/main/java/com/sappho/audiobooks/service/DownloadService.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/DownloadService.kt
@@ -279,6 +279,9 @@ class DownloadService : Service() {
                     } else {
                         emptyList()
                     }
+                } catch (e: CancellationException) {
+                    // Never swallow cancellation — the outer handler cleans up.
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to fetch chapters", e)
                     emptyList()

--- a/app/src/main/java/com/sappho/audiobooks/service/PlayerState.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/PlayerState.kt
@@ -38,6 +38,11 @@ class PlayerState @Inject constructor() {
     private val _lastActiveTimestamp = MutableStateFlow(0L)
     val lastActiveTimestamp: StateFlow<Long> = _lastActiveTimestamp
 
+    // Playback errors are surfaced here (instead of a Toast from the service)
+    // so the player UI can show a dismissible dialog the user can acknowledge.
+    private val _playbackError = MutableStateFlow<String?>(null)
+    val playbackError: StateFlow<String?> = _playbackError
+
     fun updateLastActiveTimestamp() {
         _lastActiveTimestamp.value = System.currentTimeMillis()
     }
@@ -78,6 +83,14 @@ class PlayerState @Inject constructor() {
         _bufferedPosition.value = position
     }
 
+    fun updatePlaybackError(message: String) {
+        _playbackError.value = message
+    }
+
+    fun clearPlaybackError() {
+        _playbackError.value = null
+    }
+
     /**
      * Mark playback as inactive while preserving position, duration, and audiobook
      * for UI display. Called when the service times out or is destroyed — the player
@@ -103,5 +116,6 @@ class PlayerState @Inject constructor() {
         _sleepAtEndOfChapter.value = false
         _bufferedPosition.value = 0L
         _lastActiveTimestamp.value = 0L
+        _playbackError.value = null
     }
 }

--- a/app/src/main/java/com/sappho/audiobooks/service/UploadService.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/UploadService.kt
@@ -16,6 +16,7 @@ import com.sappho.audiobooks.data.remote.SapphoApi
 import com.sappho.audiobooks.presentation.MainActivity
 import com.sappho.audiobooks.util.ProgressRequestBody
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -278,6 +279,10 @@ class UploadService : Service() {
                         }
 
                         cumulativeBytesUploaded += tempFile.length()
+                    } catch (e: CancellationException) {
+                        // Upload was cancelled — propagate so the loop stops
+                        // instead of counting it as a per-file failure.
+                        throw e
                     } catch (e: Exception) {
                         failCount++
                         Log.e(TAG, "Upload error for $fileName", e)
@@ -300,6 +305,10 @@ class UploadService : Service() {
 
                 showCompletedNotification(success, message)
 
+            } catch (e: CancellationException) {
+                // Cancellation is user-initiated (cancelCurrentUpload sets its
+                // own state) — rethrow; the finally block still cleans up.
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Upload error", e)
                 val message = "Upload failed: ${e.message}"
@@ -394,6 +403,10 @@ class UploadService : Service() {
                     showCompletedNotification(false, message)
                 }
 
+            } catch (e: CancellationException) {
+                // Cancellation is user-initiated (cancelCurrentUpload sets its
+                // own state) — rethrow; the finally block still cleans up.
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Upload error", e)
                 val message = "Upload failed: ${e.message}"

--- a/app/src/main/java/com/sappho/audiobooks/sync/ProgressSyncWorker.kt
+++ b/app/src/main/java/com/sappho/audiobooks/sync/ProgressSyncWorker.kt
@@ -17,6 +17,7 @@ import com.sappho.audiobooks.download.DownloadManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CancellationException
 
 @HiltWorker
 class ProgressSyncWorker @AssistedInject constructor(
@@ -99,6 +100,10 @@ class ProgressSyncWorker @AssistedInject constructor(
                         failureCount++
                         Log.w(TAG, "Failed to sync progress for book ${pending.audiobookId}: ${response.code()}")
                     }
+                } catch (e: CancellationException) {
+                    // WorkManager cancelled the worker — propagate instead of
+                    // counting it as a per-item failure.
+                    throw e
                 } catch (e: Exception) {
                     failureCount++
                     Log.e(TAG, "Exception syncing progress for book ${pending.audiobookId}", e)
@@ -116,6 +121,8 @@ class ProgressSyncWorker @AssistedInject constructor(
                 // All failed
                 Result.failure()
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Progress sync worker failed", e)
             Result.retry()

--- a/app/src/main/java/com/sappho/audiobooks/sync/SyncStatusManager.kt
+++ b/app/src/main/java/com/sappho/audiobooks/sync/SyncStatusManager.kt
@@ -22,7 +22,7 @@ import javax.inject.Singleton
 
 data class SyncStatus(
     val pendingCount: Int = 0,
-    val issyncing: Boolean = false,
+    val isSyncing: Boolean = false,
     val lastSyncTime: Long? = null,
     val lastSyncSuccess: Boolean = true,
     val errorMessage: String? = null,
@@ -150,7 +150,7 @@ class SyncStatusManager @Inject constructor(
 
         _syncStatus.value = current.copy(
             pendingCount = pendingCount,
-            issyncing = _isSyncing.value,
+            isSyncing = _isSyncing.value,
             lastSyncTime = _lastSyncTime.value ?: current.lastSyncTime,
             lastSyncSuccess = lastSyncSuccess ?: current.lastSyncSuccess,
             errorMessage = resolvedError,

--- a/app/src/test/java/com/sappho/audiobooks/di/NetworkModuleTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/di/NetworkModuleTest.kt
@@ -1,0 +1,104 @@
+package com.sappho.audiobooks.di
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class NetworkModuleTest {
+
+    // --- isPrivateNetworkHost (M6: RFC-1918 coverage) ---
+
+    @Test
+    fun `should treat localhost and loopback as private`() {
+        // Given / When / Then
+        assertThat(NetworkModule.isPrivateNetworkHost("localhost")).isTrue()
+        assertThat(NetworkModule.isPrivateNetworkHost("127.0.0.1")).isTrue()
+    }
+
+    @Test
+    fun `should treat 192_168 slash 16 hosts as private`() {
+        assertThat(NetworkModule.isPrivateNetworkHost("192.168.1.100")).isTrue()
+        assertThat(NetworkModule.isPrivateNetworkHost("192.168.86.151")).isTrue()
+    }
+
+    @Test
+    fun `should treat 10 slash 8 hosts as private`() {
+        assertThat(NetworkModule.isPrivateNetworkHost("10.0.0.1")).isTrue()
+        assertThat(NetworkModule.isPrivateNetworkHost("10.255.255.254")).isTrue()
+    }
+
+    @Test
+    fun `should treat 172_16 slash 12 hosts as private`() {
+        // Given: the full 172.16.0.0/12 block spans second octets 16-31
+        assertThat(NetworkModule.isPrivateNetworkHost("172.16.0.1")).isTrue()
+        assertThat(NetworkModule.isPrivateNetworkHost("172.20.10.5")).isTrue()
+        assertThat(NetworkModule.isPrivateNetworkHost("172.31.255.254")).isTrue()
+    }
+
+    @Test
+    fun `should not treat 172 hosts outside the slash 12 block as private`() {
+        assertThat(NetworkModule.isPrivateNetworkHost("172.15.0.1")).isFalse()
+        assertThat(NetworkModule.isPrivateNetworkHost("172.32.0.1")).isFalse()
+    }
+
+    @Test
+    fun `should not treat public hosts as private`() {
+        assertThat(NetworkModule.isPrivateNetworkHost("sappho.bitstorm.ca")).isFalse()
+        assertThat(NetworkModule.isPrivateNetworkHost("8.8.8.8")).isFalse()
+        assertThat(NetworkModule.isPrivateNetworkHost("193.168.1.1")).isFalse()
+    }
+
+    @Test
+    fun `should not crash on malformed 172 host`() {
+        assertThat(NetworkModule.isPrivateNetworkHost("172.")).isFalse()
+        assertThat(NetworkModule.isPrivateNetworkHost("172.abc.0.1")).isFalse()
+    }
+
+    // --- sanitizeBaseUrl (M7: Retrofit baseUrl must be path-free with trailing slash) ---
+
+    @Test
+    fun `should return default base url when stored url is null`() {
+        // Given / When
+        val result = NetworkModule.sanitizeBaseUrl(null)
+
+        // Then
+        assertThat(result).isEqualTo("http://192.168.1.100:3002/")
+    }
+
+    @Test
+    fun `should return default base url when stored url is unparseable`() {
+        val result = NetworkModule.sanitizeBaseUrl("not a url")
+
+        assertThat(result).isEqualTo("http://192.168.1.100:3002/")
+    }
+
+    @Test
+    fun `should strip path from stored url`() {
+        // Given: AuthRepository trims trailing slashes, so a sub-path install
+        // is stored as "https://host/sappho" — which crashes Retrofit's baseUrl
+        val result = NetworkModule.sanitizeBaseUrl("https://example.com/sappho")
+
+        // Then: scheme+host only, with the trailing slash Retrofit requires
+        assertThat(result).isEqualTo("https://example.com/")
+    }
+
+    @Test
+    fun `should preserve custom port`() {
+        val result = NetworkModule.sanitizeBaseUrl("http://192.168.1.50:3002")
+
+        assertThat(result).isEqualTo("http://192.168.1.50:3002/")
+    }
+
+    @Test
+    fun `should omit default port for scheme`() {
+        val result = NetworkModule.sanitizeBaseUrl("https://sappho.bitstorm.ca")
+
+        assertThat(result).isEqualTo("https://sappho.bitstorm.ca/")
+    }
+
+    @Test
+    fun `should produce retrofit-safe url for deep path with query`() {
+        val result = NetworkModule.sanitizeBaseUrl("https://example.com:8443/a/b/c?x=1")
+
+        assertThat(result).isEqualTo("https://example.com:8443/")
+    }
+}

--- a/app/src/test/java/com/sappho/audiobooks/service/AudioPlaybackServiceSkipTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/service/AudioPlaybackServiceSkipTest.kt
@@ -1,0 +1,56 @@
+package com.sappho.audiobooks.service
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Tests for the skip-forward clamping logic (M3): when the player has not yet
+ * reported a duration, skipping forward must not clamp against 0 (which would
+ * seek back to the start of the book).
+ */
+class AudioPlaybackServiceSkipTest {
+
+    @Test
+    fun `should clamp target to duration when duration is known`() {
+        // Given a 100s book and a target past the end
+        val result = AudioPlaybackService.clampSkipForwardPosition(
+            targetSeconds = 110,
+            durationSeconds = 100
+        )
+
+        // Then the seek lands on the end of the book
+        assertThat(result).isEqualTo(100)
+    }
+
+    @Test
+    fun `should keep target when below duration`() {
+        val result = AudioPlaybackService.clampSkipForwardPosition(
+            targetSeconds = 40,
+            durationSeconds = 100
+        )
+
+        assertThat(result).isEqualTo(40)
+    }
+
+    @Test
+    fun `should not clamp when duration is unknown`() {
+        // Given: duration not yet reported (0) — clamping would seek to 0
+        val result = AudioPlaybackService.clampSkipForwardPosition(
+            targetSeconds = 40,
+            durationSeconds = 0
+        )
+
+        // Then the raw target is preserved
+        assertThat(result).isEqualTo(40)
+    }
+
+    @Test
+    fun `should not clamp when duration is negative`() {
+        val result = AudioPlaybackService.clampSkipForwardPosition(
+            targetSeconds = 25,
+            durationSeconds = -1
+        )
+
+        assertThat(result).isEqualTo(25)
+    }
+}


### PR DESCRIPTION
## Summary

Second audit PR — medium/low severity fixes across ViewModels, services, and networking:

- **H3 — CancellationException sweep**: ~70 `catch (e: Exception)` blocks in coroutine contexts (HomeViewModel, AudiobookDetailViewModel, PlayerViewModel, LoginViewModel, ProgressSyncWorker, AudioPlaybackService, DownloadService, UploadService, DownloadManager) silently swallowed cancellation, breaking structured concurrency and misreporting cancelled work as errors. All now rethrow `CancellationException` first. In `AudioPlaybackService`, `SettableFuture` blocks resolve the future *before* rethrowing so Media3 controllers can't hang.
- **M1 — StateFlow races**: DownloadManager read-modify-write mutations converted to atomic `.update {}`; metadata/pending-progress file writes serialized with locks.
- **M3 — skipForward clamp**: no longer seeks past duration (only clamps when duration is known).
- **M4 — EncryptedSharedPreferences**: 3 immediate retries before the destructive wipe-and-recreate — a transient Keystore error no longer destroys valid tokens (retries are sleep-free; this runs during Hilt singleton construction on the main thread).
- **M6 — RFC1918**: private-network check now covers all of 172.16.0.0/12 (was matching only literal prefixes).
- **M7 — Retrofit baseUrl sanitization**: stored URLs with a path (reverse-proxy subpath) crashed Retrofit's `baseUrl()` at DI-graph creation. Base URL is now reduced to scheme+host+port; the rewriting interceptor preserves the subpath on every request.
- **M9** — `@Volatile` on cross-thread `currentCoverBitmap`.
- **L2** — download progress emits only on whole-percent changes.
- **L5** — player errors surface via `PlayerState.playbackError` + dismissible dialog instead of a service Toast.
- **L6** — in-app update flow migrated from deprecated `startActivityForResult` to the ActivityResult API; declined updates now reset state instead of being silently dropped.
- **L7** — `issyncing` → `isSyncing`.
- **L8** — `HomeViewModel.downloadManager` no longer exposed; screens collect narrow `downloadedBooks`/`downloadStates` flows.

## Tests

- 17 new unit tests: RFC1918 /12 boundaries (172.15 / 172.16 / 172.31 / 172.32), baseUrl sanitization (null, unparseable, path, port, default port, query), skip-forward clamping (known/unknown/negative duration).
- `./gradlew testDebugUnitTest`: **199/199 pass** (baseline 182 + 17).

## Version

versionCode 103, versionName 0.9.85

🤖 Generated with [Claude Code](https://claude.com/claude-code)