### PR TITLE
refactor: audit PR3 — dependency removal, dead code, rethrow sweep, lifecycle-aware collection (0.9.86)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.dagger.hilt.android")
     id("com.google.devtools.ksp")
-    kotlin("plugin.serialization") version "2.0.21"
     id("jacoco")
 }
 
@@ -16,8 +15,8 @@ android {
         applicationId = "com.sappho.audiobooks"
         minSdk = 26
         targetSdk = 35
-        versionCode = 103
-        versionName = "0.9.85"
+        versionCode = 104
+        versionName = "0.9.86"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -125,16 +124,6 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
 
-    // Kotlin Serialization (alternative to Gson)
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
-    implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0")
-
-    // Room (Database)
-    val roomVersion = "2.6.1"
-    implementation("androidx.room:room-runtime:$roomVersion")
-    implementation("androidx.room:room-ktx:$roomVersion")
-    ksp("androidx.room:room-compiler:$roomVersion")
-
     // Media3 (ExoPlayer)
     val media3Version = "1.5.1"
     implementation("androidx.media3:media3-exoplayer:$media3Version")
@@ -169,11 +158,6 @@ dependencies {
     // Lifecycle
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
-
-    // Accompanist (Compose utilities)
-    implementation("com.google.accompanist:accompanist-systemuicontroller:0.36.0")
-    implementation("com.google.accompanist:accompanist-permissions:0.36.0")
-    implementation("com.google.accompanist:accompanist-swiperefresh:0.36.0")
 
     // Reorderable (Drag-and-drop for LazyColumn)
     implementation("sh.calvin.reorderable:reorderable:3.0.0")

--- a/app/src/main/java/com/sappho/audiobooks/SapphoApplication.kt
+++ b/app/src/main/java/com/sappho/audiobooks/SapphoApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import coil.util.DebugLogger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import com.google.android.gms.cast.framework.CastContext
 import com.sappho.audiobooks.cast.CastHelper
@@ -43,6 +44,8 @@ class SapphoApplication : Application(), ImageLoaderFactory {
                 CastContext.getSharedInstance(this@SapphoApplication)
                 castHelper.initialize(this@SapphoApplication)
                 android.util.Log.d("SapphoApplication", "Cast initialized successfully")
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("SapphoApplication", "Error initializing Cast", e)
             }

--- a/app/src/main/java/com/sappho/audiobooks/cast/CastHelper.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/CastHelper.kt
@@ -17,6 +17,7 @@ import com.google.android.gms.cast.framework.media.RemoteMediaClient
 import com.google.android.gms.common.images.WebImage
 import com.sappho.audiobooks.data.repository.AuthRepository
 import com.sappho.audiobooks.domain.model.Audiobook
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
@@ -154,6 +155,8 @@ class CastHelper @Inject constructor(
                 // Stop any playing media first
                 try {
                     existingSession.remoteMediaClient?.stop()
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                 }
                 // End the session with stopCasting=true to also stop on the receiver
@@ -164,6 +167,8 @@ class CastHelper @Inject constructor(
             _isPlaying.value = false
             _currentPosition.value = 0L
 
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("CastHelper", "Error initializing Cast", e)
         }
@@ -260,6 +265,8 @@ class CastHelper @Inject constructor(
             // Update routes immediately
             updateAvailableRoutes(context)
 
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("CastHelper", "Error starting discovery", e)
         }
@@ -274,6 +281,8 @@ class CastHelper @Inject constructor(
                 mediaRouter?.removeCallback(it)
                 mediaRouterCallback = null
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("CastHelper", "Error stopping discovery", e)
         }
@@ -322,6 +331,8 @@ class CastHelper @Inject constructor(
                 // Stop any media first
                 try {
                     existingSession.remoteMediaClient?.stop()
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     android.util.Log.w("CastHelper", "selectRoute: Error stopping media: ${e.message}")
                 }
@@ -337,6 +348,8 @@ class CastHelper @Inject constructor(
                 performRouteSelection(context, route)
             }
 
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("CastHelper", "Error selecting route", e)
             android.widget.Toast.makeText(context, "Failed to connect: ${e.message}", android.widget.Toast.LENGTH_SHORT).show()
@@ -358,6 +371,8 @@ class CastHelper @Inject constructor(
             route.select()
 
             android.util.Log.d("CastHelper", "performRouteSelection: route.select() called, waiting for session callback...")
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("CastHelper", "Error in performRouteSelection", e)
             android.widget.Toast.makeText(context, "Failed to connect: ${e.message}", android.widget.Toast.LENGTH_SHORT).show()
@@ -383,6 +398,8 @@ class CastHelper @Inject constructor(
                 android.util.Log.e("CastHelper", "selectRouteById: Route not found for id $routeId")
                 android.widget.Toast.makeText(context, "Device not found, please try again", android.widget.Toast.LENGTH_SHORT).show()
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("CastHelper", "Error selecting route by id", e)
             android.widget.Toast.makeText(context, "Failed to connect: ${e.message}", android.widget.Toast.LENGTH_SHORT).show()
@@ -406,6 +423,8 @@ class CastHelper @Inject constructor(
                 button.routeSelector = selector
             } else {
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("CastHelper", "Error setting up MediaRouteButton", e)
         }
@@ -414,6 +433,8 @@ class CastHelper @Inject constructor(
     fun disconnectCast() {
         try {
             castContext?.sessionManager?.endCurrentSession(true)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("CastHelper", "Error disconnecting", e)
         }
@@ -524,6 +545,8 @@ class CastHelper @Inject constructor(
                 }
             }
 
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("CastHelper", "Error casting audiobook", e)
         }
@@ -537,6 +560,8 @@ class CastHelper @Inject constructor(
         try {
             getCastSession()?.remoteMediaClient?.play()
             // Don't set state here - let the callback handle it based on actual Cast receiver state
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("CastHelper", "Error sending play command", e)
         }
@@ -546,6 +571,8 @@ class CastHelper @Inject constructor(
         try {
             getCastSession()?.remoteMediaClient?.pause()
             // Don't set state here - let the callback handle it based on actual Cast receiver state
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("CastHelper", "Error sending pause command", e)
         }
@@ -554,6 +581,8 @@ class CastHelper @Inject constructor(
     fun seek(positionSeconds: Long) {
         try {
             getCastSession()?.remoteMediaClient?.seek(positionSeconds * 1000)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("CastHelper", "Error sending seek command", e)
         }

--- a/app/src/main/java/com/sappho/audiobooks/cast/CastManager.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/CastManager.kt
@@ -12,6 +12,7 @@ import com.sappho.audiobooks.cast.targets.KodiCastTarget
 import com.sappho.audiobooks.cast.targets.RokuCastTarget
 import com.sappho.audiobooks.data.repository.AuthRepository
 import com.sappho.audiobooks.domain.model.Audiobook
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -170,6 +171,8 @@ class CastManager @Inject constructor(
                             addDiscoveredDevice(kodiDevice)
                         }
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Kodi discovery error", e)
                 }
@@ -189,6 +192,8 @@ class CastManager @Inject constructor(
                         )
                         addDiscoveredDevice(airPlayDevice)
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "AirPlay discovery error", e)
                 }
@@ -407,6 +412,8 @@ class CastManager @Inject constructor(
             val isKodi = body.contains("pong")
             Log.d(TAG, "Kodi verification for $host:$port = $isKodi")
             isKodi
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.v(TAG, "Not a Kodi device at $host:$port: ${e.message}")
             false
@@ -421,6 +428,8 @@ class CastManager @Inject constructor(
                 acquire()
             }
             Log.d(TAG, "Multicast lock acquired")
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Failed to acquire multicast lock", e)
         }
@@ -435,6 +444,8 @@ class CastManager @Inject constructor(
                 }
             }
             multicastLock = null
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error releasing multicast lock", e)
         }

--- a/app/src/main/java/com/sappho/audiobooks/cast/discovery/MdnsDiscovery.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/discovery/MdnsDiscovery.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.util.Log
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -73,6 +74,8 @@ class MdnsDiscovery(private val context: Context) {
                 Log.d(TAG, "Service found: ${serviceInfo.serviceName}")
                 try {
                     nsdManager.resolveService(serviceInfo, resolveListener)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Error resolving service", e)
                 }
@@ -85,6 +88,8 @@ class MdnsDiscovery(private val context: Context) {
 
         try {
             nsdManager.discoverServices(serviceType, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start mDNS discovery", e)
             close(e)
@@ -93,6 +98,8 @@ class MdnsDiscovery(private val context: Context) {
         awaitClose {
             try {
                 nsdManager.stopServiceDiscovery(discoveryListener)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Error stopping mDNS discovery", e)
             }

--- a/app/src/main/java/com/sappho/audiobooks/cast/discovery/SsdpDiscovery.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/discovery/SsdpDiscovery.kt
@@ -1,6 +1,7 @@
 package com.sappho.audiobooks.cast.discovery
 
 import android.util.Log
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -77,6 +78,8 @@ class SsdpDiscovery {
                     break
                 }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "SSDP discovery error", e)
         } finally {
@@ -124,6 +127,8 @@ class SsdpDiscovery {
             val java_url = java.net.URL(url)
             val port = if (java_url.port == -1) java_url.defaultPort else java_url.port
             Pair(java_url.host, port)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             null
         }

--- a/app/src/main/java/com/sappho/audiobooks/cast/targets/AirPlayCastTarget.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/targets/AirPlayCastTarget.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.sappho.audiobooks.cast.CastDevice
 import com.sappho.audiobooks.cast.CastProtocol
 import com.sappho.audiobooks.cast.CastTarget
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -73,6 +74,8 @@ class AirPlayCastTarget(
                     .post("".toRequestBody("text/plain".toMediaType()))
                     .build()
                 httpClient.newCall(request).execute().close()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Error sending stop on disconnect", e)
             }
@@ -155,6 +158,8 @@ class AirPlayCastTarget(
                 _lastError.value = "Cannot reach AirPlay device. " +
                         "It may require AirPlay 2 (encrypted) which is not yet supported."
                 _isPlaying.value = false
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Error loading media on AirPlay", e)
                 _lastError.value = "Failed to cast via AirPlay: ${e.message}"
@@ -173,6 +178,8 @@ class AirPlayCastTarget(
             val body = response.body?.string()
             response.close()
             if (response.code == 200 && body?.contains("duration") == true) body else null
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             null
         }
@@ -186,6 +193,8 @@ class AirPlayCastTarget(
                 .post("".toRequestBody("text/plain".toMediaType()))
                 .build()
             httpClient.newCall(request).execute().close()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error sending play", e)
         }
@@ -199,6 +208,8 @@ class AirPlayCastTarget(
                 .post("".toRequestBody("text/plain".toMediaType()))
                 .build()
             httpClient.newCall(request).execute().close()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error sending pause", e)
         }
@@ -213,6 +224,8 @@ class AirPlayCastTarget(
                 .build()
             httpClient.newCall(request).execute().close()
             _currentPosition.value = positionSeconds
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error seeking on AirPlay", e)
         }
@@ -227,6 +240,8 @@ class AirPlayCastTarget(
                 .build()
             httpClient.newCall(request).execute().close()
             _isPlaying.value = false
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error stopping AirPlay", e)
         }
@@ -272,6 +287,8 @@ class AirPlayCastTarget(
                 _currentPosition.value = position.toLong()
                 _isPlaying.value = true
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             // Expected when no media is playing
             Log.v(TAG, "Polling error: ${e.message}")

--- a/app/src/main/java/com/sappho/audiobooks/cast/targets/KodiCastTarget.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/targets/KodiCastTarget.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.sappho.audiobooks.cast.CastDevice
 import com.sappho.audiobooks.cast.CastProtocol
 import com.sappho.audiobooks.cast.CastTarget
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -72,6 +73,8 @@ class KodiCastTarget(
                 } else {
                     Log.e(TAG, "Failed to ping Kodi at $baseUrl")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Error connecting to Kodi", e)
             }
@@ -148,6 +151,8 @@ class KodiCastTarget(
                             "The media URL may be unreachable from the Kodi device."
                     _isPlaying.value = false
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Error loading media on Kodi", e)
                 _lastError.value = "Failed to cast to Kodi: ${e.message}"
@@ -166,6 +171,8 @@ class KodiCastTarget(
                 put("playerid", playerId)
             }
             sendJsonRpc(baseUrl, "Player.PlayPause", params)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error toggling play/pause on Kodi", e)
         }
@@ -198,6 +205,8 @@ class KodiCastTarget(
             }
             sendJsonRpc(baseUrl, "Player.Seek", params)
             _currentPosition.value = positionSeconds
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error seeking on Kodi", e)
         }
@@ -215,6 +224,8 @@ class KodiCastTarget(
             sendJsonRpc(baseUrl, "Player.Stop", params)
             _isPlaying.value = false
             activePlayerId = null
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error stopping Kodi playback", e)
         }
@@ -238,6 +249,8 @@ class KodiCastTarget(
             val body = response.body?.string()
             response.close()
             body?.let { JSONObject(it) }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "JSON-RPC error for $method", e)
             null
@@ -304,6 +317,8 @@ class KodiCastTarget(
                     _currentPosition.value = hours * 3600 + minutes * 60 + seconds
                 }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.v(TAG, "Polling error: ${e.message}")
         }

--- a/app/src/main/java/com/sappho/audiobooks/cast/targets/RokuCastTarget.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/targets/RokuCastTarget.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.sappho.audiobooks.cast.CastDevice
 import com.sappho.audiobooks.cast.CastProtocol
 import com.sappho.audiobooks.cast.CastTarget
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -162,6 +163,8 @@ class RokuCastTarget(
                 Log.e(TAG, "Cannot reach Roku device", e)
                 _lastError.value = "Cannot reach Roku device. Make sure it's powered on."
                 _isPlaying.value = false
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Error loading media on Roku", e)
                 _lastError.value = "Failed to cast to Roku: ${e.message}"
@@ -180,6 +183,8 @@ class RokuCastTarget(
             val body = response.body?.string()
             response.close()
             body
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error querying media player state", e)
             null
@@ -210,6 +215,8 @@ class RokuCastTarget(
                 .build()
             httpClient.newCall(request).execute().close()
             _isPlaying.value = false
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error stopping Roku playback", e)
         }
@@ -225,6 +232,8 @@ class RokuCastTarget(
                     .post("".toRequestBody("text/plain".toMediaType()))
                     .build()
                 httpClient.newCall(request).execute().close()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Error sending keypress '$key'", e)
             }
@@ -268,6 +277,8 @@ class RokuCastTarget(
 
             _isPlaying.value = state == "play"
             _currentPosition.value = positionMs / 1000
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             // Polling failure is expected when device goes offline
             Log.v(TAG, "Polling error: ${e.message}")

--- a/app/src/main/java/com/sappho/audiobooks/cast/ui/CastDialog.kt
+++ b/app/src/main/java/com/sappho/audiobooks/cast/ui/CastDialog.kt
@@ -36,7 +36,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -54,6 +53,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sappho.audiobooks.cast.CastDevice
 import com.sappho.audiobooks.cast.CastDeviceType
 import com.sappho.audiobooks.cast.CastManager
@@ -81,10 +81,10 @@ fun CastDialog(
     onDismiss: () -> Unit
 ) {
     val context = LocalContext.current
-    val discoveredDevices by castManager.discoveredDevices.collectAsState()
-    val isCastConnected by castManager.isConnected.collectAsState()
-    val connectedDeviceName by castManager.connectedDeviceName.collectAsState()
-    val activeProtocol by castManager.activeProtocol.collectAsState()
+    val discoveredDevices by castManager.discoveredDevices.collectAsStateWithLifecycle()
+    val isCastConnected by castManager.isConnected.collectAsStateWithLifecycle()
+    val connectedDeviceName by castManager.connectedDeviceName.collectAsStateWithLifecycle()
+    val activeProtocol by castManager.activeProtocol.collectAsStateWithLifecycle()
 
     var isScanning by remember { mutableStateOf(true) }
 

--- a/app/src/main/java/com/sappho/audiobooks/data/update/InAppUpdateManager.kt
+++ b/app/src/main/java/com/sappho/audiobooks/data/update/InAppUpdateManager.kt
@@ -14,6 +14,7 @@ import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.tasks.await
@@ -83,6 +84,8 @@ class InAppUpdateManager @Inject constructor(
     private fun unregisterListener() {
         try {
             appUpdateManager.unregisterListener(installStateListener)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Failed to unregister listener", e)
         }
@@ -113,6 +116,8 @@ class InAppUpdateManager @Inject constructor(
             } else {
                 _updateState.value = UpdateState.None
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Failed to check for update", e)
             _updateState.value = UpdateState.None
@@ -135,6 +140,8 @@ class InAppUpdateManager @Inject constructor(
             // Re-register listener in case it was unregistered
             try {
                 appUpdateManager.registerListener(installStateListener)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 // Already registered
             }
@@ -157,6 +164,8 @@ class InAppUpdateManager @Inject constructor(
                 launcher,
                 AppUpdateOptions.defaultOptions(updateType)
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start update flow", e)
             _updateState.value = UpdateState.Failed("Failed to start update: ${e.message}")

--- a/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
+++ b/app/src/main/java/com/sappho/audiobooks/di/NetworkModule.kt
@@ -111,6 +111,50 @@ object NetworkModule {
     }
 
     /**
+     * Rebuilds [originalUrl] against the stored server URL, preserving the
+     * request path and query parameters.
+     *
+     * For subpath deployments (e.g. "https://host/sappho"), absolute request
+     * URLs built from the server URL (Coil cover requests, stream URLs) already
+     * contain the subpath in their path. Since the rewrite appends the original
+     * path to the server URL (which also carries the subpath), the prefix would
+     * be duplicated ("/sappho/sappho/api/..."). To prevent that, the server's
+     * path prefix is stripped from the request path when it is already present
+     * and the request targets the server host.
+     *
+     * Returns null when the server URL cannot be parsed.
+     */
+    internal fun rewriteUrlForServer(originalUrl: okhttp3.HttpUrl, serverUrl: String): okhttp3.HttpUrl? {
+        val baseUrl = if (!serverUrl.endsWith("/")) "$serverUrl/" else serverUrl
+        val httpUrl = baseUrl.toHttpUrlOrNull() ?: return null
+
+        // Strip the server's own path prefix (subpath deployment) if the
+        // request already includes it, so it isn't appended twice.
+        val serverPrefix = httpUrl.encodedPath // e.g. "/sappho/" or "/"
+        var requestPath = originalUrl.encodedPath
+        if (serverPrefix != "/" &&
+            originalUrl.host == httpUrl.host &&
+            "$requestPath/".startsWith(serverPrefix)
+        ) {
+            requestPath = requestPath.removePrefix(serverPrefix.trimEnd('/'))
+        }
+
+        // Rebuild the request URL with the dynamic server URL, preserving query parameters
+        val urlBuilder = httpUrl.newBuilder()
+            .addPathSegments(requestPath.removePrefix("/"))
+
+        // Copy all query parameters from the original request
+        for (i in 0 until originalUrl.querySize) {
+            val name = originalUrl.queryParameterName(i)
+            val value = originalUrl.queryParameterValue(i)
+            if (value != null) {
+                urlBuilder.addQueryParameter(name, value)
+            }
+        }
+        return urlBuilder.build()
+    }
+
+    /**
      * Interceptor that rewrites request URLs to the dynamically-configured
      * server URL and (optionally) injects the auth header.
      *
@@ -150,25 +194,9 @@ object NetworkModule {
             }
 
             val request = if (serverUrl != null && serverUrl.isNotBlank()) {
-                // Parse the server URL to extract components
-                val baseUrl = if (!serverUrl.endsWith("/")) "$serverUrl/" else serverUrl
-                val httpUrl = baseUrl.toHttpUrlOrNull()
+                val newUrl = rewriteUrlForServer(original.url, serverUrl)
 
-                if (httpUrl != null) {
-                    // Rebuild the request URL with the dynamic server URL, preserving query parameters
-                    val urlBuilder = httpUrl.newBuilder()
-                        .addPathSegments(original.url.encodedPath.removePrefix("/"))
-
-                    // Copy all query parameters from the original request
-                    for (i in 0 until original.url.querySize) {
-                        val name = original.url.queryParameterName(i)
-                        val value = original.url.queryParameterValue(i)
-                        if (value != null) {
-                            urlBuilder.addQueryParameter(name, value)
-                        }
-                    }
-
-                    val newUrl = urlBuilder.build()
+                if (newUrl != null) {
                     withAuth(original.newBuilder().url(newUrl)).build()
                 } else {
                     // Fall back to original if URL parsing fails
@@ -244,16 +272,6 @@ object NetworkModule {
             .addConverterFactory(GsonConverterFactory.create(gson))
             .build()
             .create(SapphoApi::class.java)
-    }
-
-    @Provides
-    @Singleton
-    @Named("localNetwork")
-    fun provideLocalOkHttpClient(): OkHttpClient {
-        return OkHttpClient.Builder()
-            .connectTimeout(5, TimeUnit.SECONDS)
-            .readTimeout(10, TimeUnit.SECONDS)
-            .build()
     }
 
     @Provides

--- a/app/src/main/java/com/sappho/audiobooks/download/DownloadManager.kt
+++ b/app/src/main/java/com/sappho/audiobooks/download/DownloadManager.kt
@@ -2,20 +2,12 @@ package com.sappho.audiobooks.download
 
 import android.content.Context
 import android.util.Log
-import com.sappho.audiobooks.data.repository.AuthRepository
 import com.sappho.audiobooks.domain.model.Audiobook
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import java.io.File
-import java.io.FileOutputStream
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -43,27 +35,15 @@ data class PendingProgress(
 
 @Singleton
 class DownloadManager @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val authRepository: AuthRepository,
-    private val api: com.sappho.audiobooks.data.remote.SapphoApi
+    @ApplicationContext private val context: Context
 ) {
     private val TAG = "DownloadManager"
-
-    // Create a dedicated OkHttpClient for downloads with long timeouts
-    private val downloadClient = OkHttpClient.Builder()
-        .connectTimeout(60, TimeUnit.SECONDS)
-        .readTimeout(10, TimeUnit.MINUTES)  // Long timeout for large files
-        .writeTimeout(10, TimeUnit.MINUTES)
-        .build()
 
     private val _downloadStates = MutableStateFlow<Map<Int, DownloadState>>(emptyMap())
     val downloadStates: StateFlow<Map<Int, DownloadState>> = _downloadStates
 
     private val _downloadedBooks = MutableStateFlow<List<DownloadedBook>>(emptyList())
     val downloadedBooks: StateFlow<List<DownloadedBook>> = _downloadedBooks
-
-    private val downloadsDir: File
-        get() = File(context.filesDir, "audiobooks").also { it.mkdirs() }
 
     private val metadataFile: File
         get() = File(context.filesDir, "downloads_metadata.json")
@@ -166,139 +146,6 @@ class DownloadManager @Inject constructor(
 
     fun getLocalFilePath(audiobookId: Int): String? {
         return getDownloadedBook(audiobookId)?.filePath
-    }
-
-    suspend fun downloadAudiobook(audiobook: Audiobook): Boolean {
-        val audiobookId = audiobook.id
-
-        // Update state to downloading
-        updateDownloadState(audiobookId, DownloadState(
-            audiobookId = audiobookId,
-            progress = 0f,
-            isDownloading = true,
-            isCompleted = false
-        ))
-
-        return withContext(Dispatchers.IO) {
-            try {
-                val serverUrl = authRepository.getServerUrlSync() ?: throw Exception("No server URL")
-                val token = authRepository.getTokenSync() ?: throw Exception("No auth token")
-
-                val downloadUrl = "$serverUrl/api/audiobooks/$audiobookId/stream"
-                Log.d(TAG, "Downloading from: $downloadUrl")
-
-                val request = Request.Builder()
-                    .url(downloadUrl)
-                    .addHeader("Authorization", "Bearer $token")
-                    .build()
-
-                Log.d(TAG, "Starting download request...")
-                val response = downloadClient.newCall(request).execute()
-                Log.d(TAG, "Response received: ${response.code}")
-
-                if (!response.isSuccessful) {
-                    throw Exception("Download failed: ${response.code}")
-                }
-
-                val body = response.body ?: throw Exception("Empty response body")
-                val contentLength = body.contentLength()
-
-                val file = File(downloadsDir, "audiobook_$audiobookId.m4b")
-
-                body.byteStream().use { inputStream ->
-                    FileOutputStream(file).use { outputStream ->
-                        val buffer = ByteArray(8192)
-                        var bytesRead: Int
-                        var totalBytesRead = 0L
-                        // Throttle progress emissions to whole-percent steps:
-                        // emitting per 8KB chunk floods the StateFlow with tens of
-                        // thousands of updates and forces needless recompositions.
-                        var lastReportedPercent = -1
-
-                        while (inputStream.read(buffer).also { bytesRead = it } != -1) {
-                            outputStream.write(buffer, 0, bytesRead)
-                            totalBytesRead += bytesRead
-
-                            val progress = if (contentLength > 0) {
-                                totalBytesRead.toFloat() / contentLength.toFloat()
-                            } else {
-                                0f
-                            }
-
-                            val percent = (progress * 100).toInt()
-                            if (percent != lastReportedPercent) {
-                                lastReportedPercent = percent
-                                updateDownloadState(audiobookId, DownloadState(
-                                    audiobookId = audiobookId,
-                                    progress = progress,
-                                    isDownloading = true,
-                                    isCompleted = false
-                                ))
-                            }
-                        }
-                    }
-                }
-
-                // Fetch chapters for offline use
-                val chapters = try {
-                    val chaptersResponse = api.getChapters(audiobookId)
-                    if (chaptersResponse.isSuccessful) {
-                        chaptersResponse.body() ?: emptyList()
-                    } else {
-                        emptyList()
-                    }
-                } catch (e: CancellationException) {
-                    // Never swallow cancellation - it must propagate so the
-                    // coroutine actually stops.
-                    throw e
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to fetch chapters for download", e)
-                    emptyList()
-                }
-
-                // Add to downloaded books
-                val downloadedBook = DownloadedBook(
-                    audiobook = audiobook,
-                    filePath = file.absolutePath,
-                    fileSize = file.length(),
-                    downloadedAt = System.currentTimeMillis(),
-                    chapters = chapters
-                )
-
-                _downloadedBooks.update { it + downloadedBook }
-                saveDownloadedBooks()
-
-                // Update state to completed
-                updateDownloadState(audiobookId, DownloadState(
-                    audiobookId = audiobookId,
-                    progress = 1f,
-                    isDownloading = false,
-                    isCompleted = true
-                ))
-
-                Log.d(TAG, "Download complete: ${file.absolutePath}")
-                true
-            } catch (e: CancellationException) {
-                // Reset UI state, then rethrow so cancellation propagates.
-                updateDownloadState(audiobookId, DownloadState(
-                    audiobookId = audiobookId,
-                    progress = 0f,
-                    isDownloading = false,
-                    isCompleted = false
-                ))
-                throw e
-            } catch (e: Exception) {
-                Log.e(TAG, "Download failed", e)
-                updateDownloadState(audiobookId, DownloadState(
-                    audiobookId = audiobookId,
-                    progress = 0f,
-                    isDownloading = false,
-                    isCompleted = false,
-                    error = e.message
-                ))
-                false
-            }
-        }
     }
 
     fun deleteDownload(audiobookId: Int): Boolean {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/MainActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/MainActivity.kt
@@ -10,9 +10,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.sappho.audiobooks.data.update.InAppUpdateManager
 import com.sappho.audiobooks.data.update.UpdateState
@@ -62,7 +62,7 @@ class MainActivity : ComponentActivity() {
 
             CompositionLocalProvider(LocalWindowSizeClass provides windowSizeClass) {
                 SapphoTheme {
-                    val updateState by inAppUpdateManager.updateState.collectAsState()
+                    val updateState by inAppUpdateManager.updateState.collectAsStateWithLifecycle()
 
                     Surface(
                     modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/sappho/audiobooks/presentation/SapphoApp.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/SapphoApp.kt
@@ -2,12 +2,12 @@ package com.sappho.audiobooks.presentation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -23,8 +23,8 @@ fun SapphoApp(
     initialSeries: String? = null
 ) {
     val navController = rememberNavController()
-    val isAuthenticated by authRepository.isAuthenticated.collectAsState()
-    val authError by authRepository.authError.collectAsState()
+    val isAuthenticated by authRepository.isAuthenticated.collectAsStateWithLifecycle()
+    val authError by authRepository.authError.collectAsStateWithLifecycle()
 
     val startDestination = if (isAuthenticated) "main" else "login"
 

--- a/app/src/main/java/com/sappho/audiobooks/presentation/admin/AdminScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/admin/AdminScreen.kt
@@ -15,15 +15,16 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
-import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.window.Dialog
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sappho.audiobooks.domain.model.UploadState
 import com.sappho.audiobooks.presentation.theme.*
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -63,7 +64,7 @@ fun AdminScreen(
     viewModel: AdminViewModel = hiltViewModel()
 ) {
     var selectedSection by remember { mutableStateOf<AdminSection?>(null) }
-    val message by viewModel.message.collectAsState()
+    val message by viewModel.message.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(message) {
@@ -252,14 +253,15 @@ private fun AdminSectionContent(
 }
 
 // ============ Library Tab ============
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LibraryTab(viewModel: AdminViewModel) {
-    val serverSettings by viewModel.serverSettings.collectAsState()
-    val duplicates by viewModel.duplicates.collectAsState()
-    val jobs by viewModel.jobs.collectAsState()
-    val orphanDirectories by viewModel.orphanDirectories.collectAsState()
-    val organizePreview by viewModel.organizePreview.collectAsState()
-    val loadingSection by viewModel.loadingSection.collectAsState()
+    val serverSettings by viewModel.serverSettings.collectAsStateWithLifecycle()
+    val duplicates by viewModel.duplicates.collectAsStateWithLifecycle()
+    val jobs by viewModel.jobs.collectAsStateWithLifecycle()
+    val orphanDirectories by viewModel.orphanDirectories.collectAsStateWithLifecycle()
+    val organizePreview by viewModel.organizePreview.collectAsStateWithLifecycle()
+    val loadingSection by viewModel.loadingSection.collectAsStateWithLifecycle()
     val isLoading = loadingSection == "serverSettings" || loadingSection == "library"
     var showEditDialog by remember { mutableStateOf(false) }
     var selectedDuplicateGroup by remember { mutableStateOf<DuplicateGroup?>(null) }
@@ -278,20 +280,22 @@ private fun LibraryTab(viewModel: AdminViewModel) {
         if (loadingSection != "library") isRefreshing = false
     }
 
-    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing)
+    val pullToRefreshState = rememberPullToRefreshState()
 
-    SwipeRefresh(
-        state = swipeRefreshState,
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
         onRefresh = {
             isRefreshing = true
             viewModel.refreshLibraryTab()
         },
-        indicator = { state, trigger ->
-            SwipeRefreshIndicator(
-                state = state,
-                refreshTriggerDistance = trigger,
-                backgroundColor = SapphoSurfaceLight,
-                contentColor = SapphoInfo
+        state = pullToRefreshState,
+        indicator = {
+            PullToRefreshDefaults.Indicator(
+                state = pullToRefreshState,
+                isRefreshing = isRefreshing,
+                modifier = Modifier.align(Alignment.TopCenter),
+                containerColor = SapphoSurfaceLight,
+                color = SapphoInfo
             )
         },
         modifier = Modifier.fillMaxSize()
@@ -805,8 +809,8 @@ private fun LockedField(label: String, value: String) {
 // ============ Server Settings Tab ============
 @Composable
 private fun ServerSettingsTab(viewModel: AdminViewModel) {
-    val serverSettings by viewModel.serverSettings.collectAsState()
-    val loadingSection by viewModel.loadingSection.collectAsState()
+    val serverSettings by viewModel.serverSettings.collectAsStateWithLifecycle()
+    val loadingSection by viewModel.loadingSection.collectAsStateWithLifecycle()
     val isLoading = loadingSection == "serverSettings"
     var showEditDialog by remember { mutableStateOf(false) }
 
@@ -995,8 +999,8 @@ private fun EditServerSettingsDialog(
 // ============ AI Settings Tab ============
 @Composable
 private fun AiSettingsTab(viewModel: AdminViewModel) {
-    val aiSettings by viewModel.aiSettings.collectAsState()
-    val loadingSection by viewModel.loadingSection.collectAsState()
+    val aiSettings by viewModel.aiSettings.collectAsStateWithLifecycle()
+    val loadingSection by viewModel.loadingSection.collectAsStateWithLifecycle()
     val isLoading = loadingSection == "aiSettings"
     var showProviderDialog by remember { mutableStateOf(false) }
     var showRecapDialog by remember { mutableStateOf(false) }
@@ -1400,10 +1404,11 @@ private fun EditRecapSettingsDialog(
 }
 
 // ============ Users Tab ============
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun UsersTab(viewModel: AdminViewModel) {
-    val users by viewModel.users.collectAsState()
-    val loadingSection by viewModel.loadingSection.collectAsState()
+    val users by viewModel.users.collectAsStateWithLifecycle()
+    val loadingSection by viewModel.loadingSection.collectAsStateWithLifecycle()
     var showCreateDialog by remember { mutableStateOf(false) }
     var editingUser by remember { mutableStateOf<UserInfo?>(null) }
     var userToDelete by remember { mutableStateOf<UserInfo?>(null) }
@@ -1417,20 +1422,22 @@ private fun UsersTab(viewModel: AdminViewModel) {
         if (loadingSection != "users") isRefreshing = false
     }
 
-    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing)
+    val pullToRefreshState = rememberPullToRefreshState()
 
-    SwipeRefresh(
-        state = swipeRefreshState,
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
         onRefresh = {
             isRefreshing = true
             viewModel.refreshUsers()
         },
-        indicator = { state, trigger ->
-            SwipeRefreshIndicator(
-                state = state,
-                refreshTriggerDistance = trigger,
-                backgroundColor = SapphoSurfaceLight,
-                contentColor = SapphoInfo
+        state = pullToRefreshState,
+        indicator = {
+            PullToRefreshDefaults.Indicator(
+                state = pullToRefreshState,
+                isRefreshing = isRefreshing,
+                modifier = Modifier.align(Alignment.TopCenter),
+                containerColor = SapphoSurfaceLight,
+                color = SapphoInfo
             )
         },
         modifier = Modifier.fillMaxSize()
@@ -1790,10 +1797,11 @@ private fun EditUserDialog(
 }
 
 // ============ API Keys Tab ============
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ApiKeysTab(viewModel: AdminViewModel) {
-    val apiKeys by viewModel.apiKeys.collectAsState()
-    val loadingSection by viewModel.loadingSection.collectAsState()
+    val apiKeys by viewModel.apiKeys.collectAsStateWithLifecycle()
+    val loadingSection by viewModel.loadingSection.collectAsStateWithLifecycle()
     var showCreateDialog by remember { mutableStateOf(false) }
     var keyToDelete by remember { mutableStateOf<ApiKey?>(null) }
     var newlyCreatedKey by remember { mutableStateOf<CreateApiKeyResponse?>(null) }
@@ -1807,20 +1815,22 @@ private fun ApiKeysTab(viewModel: AdminViewModel) {
         if (loadingSection != "apiKeys") isRefreshing = false
     }
 
-    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing)
+    val pullToRefreshState = rememberPullToRefreshState()
 
-    SwipeRefresh(
-        state = swipeRefreshState,
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
         onRefresh = {
             isRefreshing = true
             viewModel.refreshApiKeys()
         },
-        indicator = { state, trigger ->
-            SwipeRefreshIndicator(
-                state = state,
-                refreshTriggerDistance = trigger,
-                backgroundColor = SapphoSurfaceLight,
-                contentColor = SapphoInfo
+        state = pullToRefreshState,
+        indicator = {
+            PullToRefreshDefaults.Indicator(
+                state = pullToRefreshState,
+                isRefreshing = isRefreshing,
+                modifier = Modifier.align(Alignment.TopCenter),
+                containerColor = SapphoSurfaceLight,
+                color = SapphoInfo
             )
         },
         modifier = Modifier.fillMaxSize()
@@ -2260,11 +2270,12 @@ private fun NewApiKeyDialog(
 }
 
 // ============ Backup Tab ============
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BackupTab(viewModel: AdminViewModel) {
-    val backups by viewModel.backups.collectAsState()
-    val serverSettings by viewModel.serverSettings.collectAsState()
-    val loadingSection by viewModel.loadingSection.collectAsState()
+    val backups by viewModel.backups.collectAsStateWithLifecycle()
+    val serverSettings by viewModel.serverSettings.collectAsStateWithLifecycle()
+    val loadingSection by viewModel.loadingSection.collectAsStateWithLifecycle()
     var backupToDelete by remember { mutableStateOf<BackupInfo?>(null) }
     var backupToRestore by remember { mutableStateOf<BackupInfo?>(null) }
     var isRefreshing by remember { mutableStateOf(false) }
@@ -2277,20 +2288,22 @@ private fun BackupTab(viewModel: AdminViewModel) {
         if (loadingSection != "backups") isRefreshing = false
     }
 
-    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing)
+    val pullToRefreshState = rememberPullToRefreshState()
 
-    SwipeRefresh(
-        state = swipeRefreshState,
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
         onRefresh = {
             isRefreshing = true
             viewModel.refreshBackups()
         },
-        indicator = { state, trigger ->
-            SwipeRefreshIndicator(
-                state = state,
-                refreshTriggerDistance = trigger,
-                backgroundColor = SapphoSurfaceLight,
-                contentColor = SapphoInfo
+        state = pullToRefreshState,
+        indicator = {
+            PullToRefreshDefaults.Indicator(
+                state = pullToRefreshState,
+                isRefreshing = isRefreshing,
+                modifier = Modifier.align(Alignment.TopCenter),
+                containerColor = SapphoSurfaceLight,
+                color = SapphoInfo
             )
         },
         modifier = Modifier.fillMaxSize()
@@ -2766,8 +2779,8 @@ private fun DuplicateMergeDialog(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LogsTab(viewModel: AdminViewModel) {
-    val logs by viewModel.logs.collectAsState()
-    val loadingSection by viewModel.loadingSection.collectAsState()
+    val logs by viewModel.logs.collectAsStateWithLifecycle()
+    val loadingSection by viewModel.loadingSection.collectAsStateWithLifecycle()
     val isLoading = loadingSection == "logs"
     var selectedLevel by remember { mutableStateOf<String?>(null) }
     var autoRefresh by remember { mutableStateOf(false) }
@@ -2809,20 +2822,22 @@ private fun LogsTab(viewModel: AdminViewModel) {
         }
     }
 
-    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing)
+    val pullToRefreshState = rememberPullToRefreshState()
 
-    SwipeRefresh(
-        state = swipeRefreshState,
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
         onRefresh = {
             isRefreshing = true
             viewModel.refreshLogs(level = selectedLevel)
         },
-        indicator = { state, trigger ->
-            SwipeRefreshIndicator(
-                state = state,
-                refreshTriggerDistance = trigger,
-                backgroundColor = SapphoSurfaceLight,
-                contentColor = SapphoInfo
+        state = pullToRefreshState,
+        indicator = {
+            PullToRefreshDefaults.Indicator(
+                state = pullToRefreshState,
+                isRefreshing = isRefreshing,
+                modifier = Modifier.align(Alignment.TopCenter),
+                containerColor = SapphoSurfaceLight,
+                color = SapphoInfo
             )
         },
         modifier = Modifier.fillMaxSize()
@@ -3031,15 +3046,16 @@ private fun LogEntryCard(log: LogEntry) {
 }
 
 // ============ Statistics Tab ============
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun StatisticsTab(viewModel: AdminViewModel, onBookClick: (Int) -> Unit) {
-    val statistics by viewModel.statistics.collectAsState()
-    val loadingSection by viewModel.loadingSection.collectAsState()
+    val statistics by viewModel.statistics.collectAsStateWithLifecycle()
+    val loadingSection by viewModel.loadingSection.collectAsStateWithLifecycle()
     val isLoading = loadingSection == "statistics"
     var isRefreshing by remember { mutableStateOf(false) }
     var selectedFormat by remember { mutableStateOf<FormatStats?>(null) }
-    val formatBooks by viewModel.formatBooks.collectAsState()
-    val isLoadingFormatBooks by viewModel.isLoadingFormatBooks.collectAsState()
+    val formatBooks by viewModel.formatBooks.collectAsStateWithLifecycle()
+    val isLoadingFormatBooks by viewModel.isLoadingFormatBooks.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         viewModel.loadStatistics()
@@ -3050,20 +3066,22 @@ private fun StatisticsTab(viewModel: AdminViewModel, onBookClick: (Int) -> Unit)
         if (!isLoading) isRefreshing = false
     }
 
-    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing)
+    val pullToRefreshState = rememberPullToRefreshState()
 
-    SwipeRefresh(
-        state = swipeRefreshState,
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
         onRefresh = {
             isRefreshing = true
             viewModel.refreshStatistics()
         },
-        indicator = { state, trigger ->
-            SwipeRefreshIndicator(
-                state = state,
-                refreshTriggerDistance = trigger,
-                backgroundColor = SapphoSurfaceLight,
-                contentColor = SapphoInfo
+        state = pullToRefreshState,
+        indicator = {
+            PullToRefreshDefaults.Indicator(
+                state = pullToRefreshState,
+                isRefreshing = isRefreshing,
+                modifier = Modifier.align(Alignment.TopCenter),
+                containerColor = SapphoSurfaceLight,
+                color = SapphoInfo
             )
         },
         modifier = Modifier.fillMaxSize()
@@ -3742,9 +3760,9 @@ private fun UploadDialog(
     onDismiss: () -> Unit
 ) {
     val context = LocalContext.current
-    val uploadState by viewModel.uploadState.collectAsState()
-    val uploadProgress by viewModel.uploadProgress.collectAsState()
-    val uploadResult by viewModel.uploadResult.collectAsState()
+    val uploadState by viewModel.uploadState.collectAsStateWithLifecycle()
+    val uploadProgress by viewModel.uploadProgress.collectAsStateWithLifecycle()
+    val uploadResult by viewModel.uploadResult.collectAsStateWithLifecycle()
 
     var selectedFiles by remember { mutableStateOf<List<Uri>>(emptyList()) }
     var title by remember { mutableStateOf("") }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/admin/AdminViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/admin/AdminViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.sappho.audiobooks.data.remote.*
 import com.sappho.audiobooks.domain.model.UploadState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -121,6 +122,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     android.util.Log.e("AdminViewModel", "Server settings error: ${response.code()}")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Server settings exception", e)
                 _message.value = "Failed to load server settings"
@@ -138,6 +141,8 @@ class AdminViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _serverSettings.value = response.body()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Failed to load server settings"
             } finally {
@@ -157,6 +162,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to update settings"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -179,6 +186,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     android.util.Log.e("AdminViewModel", "AI settings error: ${response.code()}")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "AI settings exception", e)
                 _message.value = "Failed to load AI settings"
@@ -196,6 +205,8 @@ class AdminViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _aiSettings.value = response.body()?.settings
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Failed to load AI settings"
             } finally {
@@ -215,6 +226,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to update AI settings"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -233,6 +246,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "AI test failed"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -255,6 +270,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     android.util.Log.e("AdminViewModel", "Users error: ${response.code()}")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Users exception", e)
                 _message.value = "Failed to load users"
@@ -272,6 +289,8 @@ class AdminViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _users.value = response.body() ?: emptyList()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Failed to load users"
             } finally {
@@ -292,6 +311,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to create user"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -312,6 +333,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to update user"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -331,6 +354,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to delete user"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -354,6 +379,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to update user status"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -376,6 +403,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     android.util.Log.e("AdminViewModel", "Backups error: ${response.code()}")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Backups exception", e)
                 _message.value = "Failed to load backups"
@@ -398,6 +427,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     android.util.Log.e("AdminViewModel", "Backup retention failed: ${response.code()} - ${response.message()}")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Backup retention exception", e)
             }
@@ -412,6 +443,8 @@ class AdminViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _backups.value = response.body()?.backups ?: emptyList()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Failed to load backups"
             } finally {
@@ -431,6 +464,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to create backup"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -450,6 +485,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to delete backup"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -468,6 +505,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to restore backup"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -487,6 +526,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to update retention"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -509,6 +550,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     android.util.Log.e("AdminViewModel", "Logs error: ${response.code()}")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Logs exception", e)
                 _message.value = "Failed to load logs"
@@ -526,6 +569,8 @@ class AdminViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _logs.value = response.body()?.logs ?: emptyList()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Failed to load logs"
             } finally {
@@ -545,6 +590,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to clear logs"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -566,6 +613,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     android.util.Log.e("AdminViewModel", "Statistics error: ${response.code()}")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Statistics exception", e)
                 _message.value = "Failed to load statistics"
@@ -583,6 +632,8 @@ class AdminViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _statistics.value = response.body()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Statistics refresh exception", e)
             } finally {
@@ -610,6 +661,8 @@ class AdminViewModel @Inject constructor(
                     }
                     _formatBooks.value = allBooks.take(50) // Limit to 50 for performance
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Load format books exception", e)
             } finally {
@@ -650,6 +703,8 @@ class AdminViewModel @Inject constructor(
                 if (orphansResponse.isSuccessful) {
                     _orphanDirectories.value = orphansResponse.body()?.orphanDirectories ?: emptyList()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Library tab refresh exception", e)
             } finally {
@@ -671,6 +726,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     android.util.Log.e("AdminViewModel", "Duplicates error: ${response.code()}")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Duplicates exception", e)
                 _message.value = "Failed to load duplicates"
@@ -688,6 +745,8 @@ class AdminViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _duplicates.value = response.body()?.duplicateGroups ?: emptyList()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Failed to load duplicates"
             } finally {
@@ -707,6 +766,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to merge duplicates"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -730,6 +791,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     android.util.Log.e("AdminViewModel", "Jobs error: ${response.code()}")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Jobs exception", e)
                 _message.value = "Failed to load jobs"
@@ -748,6 +811,8 @@ class AdminViewModel @Inject constructor(
                     val jobsMap = response.body()?.jobs ?: emptyMap()
                     _jobs.value = jobsMap.map { (key, job) -> job.copy(id = key) }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Failed to refresh jobs"
             } finally {
@@ -767,6 +832,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to trigger job"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -789,6 +856,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     android.util.Log.e("AdminViewModel", "Orphans error: ${response.code()}")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Orphans exception", e)
                 _message.value = "Failed to load orphan directories"
@@ -806,6 +875,8 @@ class AdminViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _orphanDirectories.value = response.body()?.orphanDirectories ?: emptyList()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Failed to refresh orphan directories"
             } finally {
@@ -826,6 +897,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to delete orphan directories"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -845,6 +918,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     android.util.Log.e("AdminViewModel", "Organize preview error: ${response.code()}")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Organize preview exception", e)
                 _message.value = "Failed to load organization preview"
@@ -866,6 +941,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to organize library"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -885,6 +962,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to scan library"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -904,6 +983,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to rescan library"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -924,6 +1005,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to clear library"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -946,6 +1029,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     android.util.Log.e("AdminViewModel", "API keys error: ${response.code()}")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "API keys exception", e)
                 _message.value = "Failed to load API keys"
@@ -963,6 +1048,8 @@ class AdminViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _apiKeys.value = response.body() ?: emptyList()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Failed to load API keys"
             } finally {
@@ -986,6 +1073,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to create API key"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -1007,6 +1096,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to update API key"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -1026,6 +1117,8 @@ class AdminViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to delete API key"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -1088,6 +1181,8 @@ class AdminViewModel @Inject constructor(
                             failCount++
                             android.util.Log.e("AdminViewModel", "Upload failed: ${response.code()}")
                         }
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         failCount++
                         android.util.Log.e("AdminViewModel", "Upload error for file", e)
@@ -1107,6 +1202,8 @@ class AdminViewModel @Inject constructor(
                     }
                 )
 
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AdminViewModel", "Upload error", e)
                 _uploadState.value = UploadState.ERROR

--- a/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionDetailScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.sappho.audiobooks.domain.model.Audiobook
 import com.sappho.audiobooks.presentation.theme.*
@@ -51,11 +52,11 @@ fun CollectionDetailScreen(
     onBackClick: () -> Unit = {},
     viewModel: CollectionDetailViewModel = hiltViewModel()
 ) {
-    val collection by viewModel.collection.collectAsState()
-    val isLoading by viewModel.isLoading.collectAsState()
-    val serverUrl by viewModel.serverUrl.collectAsState()
-    val error by viewModel.error.collectAsState()
-    val isSaving by viewModel.isSaving.collectAsState()
+    val collection by viewModel.collection.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val serverUrl by viewModel.serverUrl.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
+    val isSaving by viewModel.isSaving.collectAsStateWithLifecycle()
 
     var showEditDialog by remember { mutableStateOf(false) }
     var isEditMode by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionDetailViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionDetailViewModel.kt
@@ -7,6 +7,7 @@ import com.sappho.audiobooks.data.remote.SapphoApi
 import com.sappho.audiobooks.data.remote.UpdateCollectionRequest
 import com.sappho.audiobooks.data.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -48,6 +49,8 @@ class CollectionDetailViewModel @Inject constructor(
                 } else {
                     _error.value = "Failed to load collection"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _error.value = e.message ?: "Network error"
             } finally {
@@ -76,6 +79,8 @@ class CollectionDetailViewModel @Inject constructor(
                 } else {
                     onResult(false, "Failed to update collection")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 onResult(false, e.message ?: "Error updating collection")
             } finally {
@@ -94,6 +99,8 @@ class CollectionDetailViewModel @Inject constructor(
                 } else {
                     onResult(false, "Failed to remove book")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 onResult(false, e.message ?: "Error removing book")
             }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionsScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionsScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.sappho.audiobooks.data.remote.Collection
 import com.sappho.audiobooks.presentation.theme.*
@@ -56,10 +57,10 @@ fun CollectionsScreen(
     onBackClick: () -> Unit = {},
     viewModel: CollectionsViewModel = hiltViewModel()
 ) {
-    val collections by viewModel.collections.collectAsState()
-    val isLoading by viewModel.isLoading.collectAsState()
-    val serverUrl by viewModel.serverUrl.collectAsState()
-    val isCreating by viewModel.isCreating.collectAsState()
+    val collections by viewModel.collections.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val serverUrl by viewModel.serverUrl.collectAsStateWithLifecycle()
+    val isCreating by viewModel.isCreating.collectAsStateWithLifecycle()
 
     var showCreateDialog by remember { mutableStateOf(false) }
     var isEditMode by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionsViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/collections/CollectionsViewModel.kt
@@ -7,6 +7,7 @@ import com.sappho.audiobooks.data.remote.CreateCollectionRequest
 import com.sappho.audiobooks.data.remote.SapphoApi
 import com.sappho.audiobooks.data.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -49,6 +50,8 @@ class CollectionsViewModel @Inject constructor(
                 } else {
                     _error.value = "Failed to load collections"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _error.value = e.message ?: "Network error"
             } finally {
@@ -68,6 +71,8 @@ class CollectionsViewModel @Inject constructor(
                 } else {
                     onResult(false, "Failed to create collection")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 onResult(false, e.message ?: "Error creating collection")
             } finally {
@@ -86,6 +91,8 @@ class CollectionsViewModel @Inject constructor(
                 } else {
                     onResult(false, "Failed to delete collection")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 onResult(false, e.message ?: "Error deleting collection")
             }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/components/BookCollectionsController.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/components/BookCollectionsController.kt
@@ -1,0 +1,104 @@
+package com.sappho.audiobooks.presentation.components
+
+import android.util.Log
+import com.sappho.audiobooks.data.remote.AddToCollectionRequest
+import com.sappho.audiobooks.data.remote.Collection
+import com.sappho.audiobooks.data.remote.CreateCollectionRequest
+import com.sappho.audiobooks.data.remote.SapphoApi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Shared "add book to collection" state and actions used by the collection
+ * picker sheet on both the Home and Audiobook Detail screens. ViewModels
+ * instantiate this with their own [viewModelScope][androidx.lifecycle.viewModelScope]
+ * and delegate to it, so the logic lives in exactly one place.
+ */
+class BookCollectionsController(
+    private val api: SapphoApi,
+    private val scope: CoroutineScope,
+    private val tag: String
+) {
+    private val _collections = MutableStateFlow<List<Collection>>(emptyList())
+    val collections: StateFlow<List<Collection>> = _collections
+
+    private val _bookCollections = MutableStateFlow<Set<Int>>(emptySet())
+    val bookCollections: StateFlow<Set<Int>> = _bookCollections
+
+    private val _isLoadingCollections = MutableStateFlow(false)
+    val isLoadingCollections: StateFlow<Boolean> = _isLoadingCollections
+
+    fun loadCollectionsForBook(bookId: Int) {
+        scope.launch {
+            _isLoadingCollections.value = true
+            try {
+                val collectionsResponse = api.getCollections()
+                val bookCollectionsResponse = api.getCollectionsForBook(bookId)
+
+                if (collectionsResponse.isSuccessful) {
+                    _collections.value = collectionsResponse.body() ?: emptyList()
+                }
+                if (bookCollectionsResponse.isSuccessful) {
+                    _bookCollections.value = (bookCollectionsResponse.body() ?: emptyList())
+                        .filter { it.containsBook == 1 }
+                        .map { it.id }
+                        .toSet()
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(tag, "Failed to load collections for book", e)
+            } finally {
+                _isLoadingCollections.value = false
+            }
+        }
+    }
+
+    fun toggleBookInCollection(collectionId: Int, bookId: Int) {
+        scope.launch {
+            val isInCollection = _bookCollections.value.contains(collectionId)
+            try {
+                if (isInCollection) {
+                    val response = api.removeFromCollection(collectionId, bookId)
+                    if (response.isSuccessful) {
+                        _bookCollections.value = _bookCollections.value - collectionId
+                    }
+                } else {
+                    val response = api.addToCollection(collectionId, AddToCollectionRequest(bookId))
+                    if (response.isSuccessful) {
+                        _bookCollections.value = _bookCollections.value + collectionId
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(tag, "Failed to toggle book in collection", e)
+            }
+        }
+    }
+
+    fun createCollectionAndAddBook(name: String, bookId: Int, isPublic: Boolean = false) {
+        scope.launch {
+            try {
+                val createResponse = api.createCollection(CreateCollectionRequest(name, null, isPublic))
+                if (createResponse.isSuccessful) {
+                    val newCollection = createResponse.body()
+                    if (newCollection != null) {
+                        val addResponse = api.addToCollection(newCollection.id, AddToCollectionRequest(bookId))
+                        if (addResponse.isSuccessful) {
+                            _collections.value = listOf(newCollection) + _collections.value
+                            _bookCollections.value = _bookCollections.value + newCollection.id
+                        }
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(tag, "Failed to create collection and add book", e)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.sappho.audiobooks.presentation.detail
 
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sappho.audiobooks.domain.model.Progress
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.animateFloatAsState
@@ -91,36 +92,36 @@ fun AudiobookDetailScreen(
     isAdmin: Boolean = false,
     viewModel: AudiobookDetailViewModel = hiltViewModel()
 ) {
-    val audiobook by viewModel.audiobook.collectAsState()
-    val progress by viewModel.progress.collectAsState()
-    val isProgressLoading by viewModel.isProgressLoading.collectAsState()
-    val chapters by viewModel.chapters.collectAsState()
-    val files by viewModel.files.collectAsState()
-    val serverUrl by viewModel.serverUrl.collectAsState()
-    val coverVersion by viewModel.coverVersion.collectAsState()
-    val isLoading by viewModel.isLoading.collectAsState()
-    val isOffline by viewModel.isOffline.collectAsState()
-    val isFavorite by viewModel.isFavorite.collectAsState()
-    val isTogglingFavorite by viewModel.isTogglingFavorite.collectAsState()
-    val userRating by viewModel.userRating.collectAsState()
-    val averageRating by viewModel.averageRating.collectAsState()
-    val isUpdatingRating by viewModel.isUpdatingRating.collectAsState()
-    val reviews by viewModel.reviews.collectAsState()
-    val userReviewText by viewModel.userReviewText.collectAsState()
-    val currentUserId by viewModel.currentUserId.collectAsState()
-    val isSavingMetadata by viewModel.isSavingMetadata.collectAsState()
-    val metadataSaveResult by viewModel.metadataSaveResult.collectAsState()
-    val isSearchingMetadata by viewModel.isSearchingMetadata.collectAsState()
-    val metadataSearchResults by viewModel.metadataSearchResults.collectAsState()
-    val metadataSearchError by viewModel.metadataSearchError.collectAsState()
-    val isEmbeddingMetadata by viewModel.isEmbeddingMetadata.collectAsState()
-    val embedMetadataResult by viewModel.embedMetadataResult.collectAsState()
-    val isSavingChapters by viewModel.isSavingChapters.collectAsState()
-    val chapterSaveResult by viewModel.chapterSaveResult.collectAsState()
-    val isFetchingChapters by viewModel.isFetchingChapters.collectAsState()
-    val fetchChaptersResult by viewModel.fetchChaptersResult.collectAsState()
-    val isDeletingFile by viewModel.isDeletingFile.collectAsState()
-    val deleteFileError by viewModel.deleteFileError.collectAsState()
+    val audiobook by viewModel.audiobook.collectAsStateWithLifecycle()
+    val progress by viewModel.progress.collectAsStateWithLifecycle()
+    val isProgressLoading by viewModel.isProgressLoading.collectAsStateWithLifecycle()
+    val chapters by viewModel.chapters.collectAsStateWithLifecycle()
+    val files by viewModel.files.collectAsStateWithLifecycle()
+    val serverUrl by viewModel.serverUrl.collectAsStateWithLifecycle()
+    val coverVersion by viewModel.coverVersion.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val isOffline by viewModel.isOffline.collectAsStateWithLifecycle()
+    val isFavorite by viewModel.isFavorite.collectAsStateWithLifecycle()
+    val isTogglingFavorite by viewModel.isTogglingFavorite.collectAsStateWithLifecycle()
+    val userRating by viewModel.userRating.collectAsStateWithLifecycle()
+    val averageRating by viewModel.averageRating.collectAsStateWithLifecycle()
+    val isUpdatingRating by viewModel.isUpdatingRating.collectAsStateWithLifecycle()
+    val reviews by viewModel.reviews.collectAsStateWithLifecycle()
+    val userReviewText by viewModel.userReviewText.collectAsStateWithLifecycle()
+    val currentUserId by viewModel.currentUserId.collectAsStateWithLifecycle()
+    val isSavingMetadata by viewModel.isSavingMetadata.collectAsStateWithLifecycle()
+    val metadataSaveResult by viewModel.metadataSaveResult.collectAsStateWithLifecycle()
+    val isSearchingMetadata by viewModel.isSearchingMetadata.collectAsStateWithLifecycle()
+    val metadataSearchResults by viewModel.metadataSearchResults.collectAsStateWithLifecycle()
+    val metadataSearchError by viewModel.metadataSearchError.collectAsStateWithLifecycle()
+    val isEmbeddingMetadata by viewModel.isEmbeddingMetadata.collectAsStateWithLifecycle()
+    val embedMetadataResult by viewModel.embedMetadataResult.collectAsStateWithLifecycle()
+    val isSavingChapters by viewModel.isSavingChapters.collectAsStateWithLifecycle()
+    val chapterSaveResult by viewModel.chapterSaveResult.collectAsStateWithLifecycle()
+    val isFetchingChapters by viewModel.isFetchingChapters.collectAsStateWithLifecycle()
+    val fetchChaptersResult by viewModel.fetchChaptersResult.collectAsStateWithLifecycle()
+    val isDeletingFile by viewModel.isDeletingFile.collectAsStateWithLifecycle()
+    val deleteFileError by viewModel.deleteFileError.collectAsStateWithLifecycle()
     var showChaptersDialog by remember { mutableStateOf(false) }
     var fileToDelete by remember { mutableStateOf<com.sappho.audiobooks.domain.model.DirectoryFile?>(null) }
     var showEditMetadataDialog by remember { mutableStateOf(false) }
@@ -128,38 +129,38 @@ fun AudiobookDetailScreen(
     var showDeleteBookDialog by remember { mutableStateOf(false) }
     var showOverflowMenu by remember { mutableStateOf(false) }
     var showRemoveDownloadConfirm by remember { mutableStateOf(false) }
-    val isRefreshingMetadata by viewModel.isRefreshingMetadata.collectAsState()
-    val refreshMetadataResult by viewModel.refreshMetadataResult.collectAsState()
-    val isConverting by viewModel.isConverting.collectAsState()
-    val convertResult by viewModel.convertResult.collectAsState()
-    val conversionProgress by viewModel.conversionProgress.collectAsState()
+    val isRefreshingMetadata by viewModel.isRefreshingMetadata.collectAsStateWithLifecycle()
+    val refreshMetadataResult by viewModel.refreshMetadataResult.collectAsStateWithLifecycle()
+    val isConverting by viewModel.isConverting.collectAsStateWithLifecycle()
+    val convertResult by viewModel.convertResult.collectAsStateWithLifecycle()
+    val conversionProgress by viewModel.conversionProgress.collectAsStateWithLifecycle()
 
-    val collections by viewModel.collections.collectAsState()
-    val bookCollections by viewModel.bookCollections.collectAsState()
-    val isLoadingCollections by viewModel.isLoadingCollections.collectAsState()
+    val collections by viewModel.collections.collectAsStateWithLifecycle()
+    val bookCollections by viewModel.bookCollections.collectAsStateWithLifecycle()
+    val isLoadingCollections by viewModel.isLoadingCollections.collectAsStateWithLifecycle()
 
     // AI Recap (Catch Up)
-    val isAiConfigured by viewModel.isAiConfigured.collectAsState()
-    val recap by viewModel.recap.collectAsState()
-    val isLoadingRecap by viewModel.isLoadingRecap.collectAsState()
-    val recapError by viewModel.recapError.collectAsState()
-    val previousBookCompleted by viewModel.previousBookCompleted.collectAsState()
+    val isAiConfigured by viewModel.isAiConfigured.collectAsStateWithLifecycle()
+    val recap by viewModel.recap.collectAsStateWithLifecycle()
+    val isLoadingRecap by viewModel.isLoadingRecap.collectAsStateWithLifecycle()
+    val recapError by viewModel.recapError.collectAsStateWithLifecycle()
+    val previousBookCompleted by viewModel.previousBookCompleted.collectAsStateWithLifecycle()
     var showRecapDialog by remember { mutableStateOf(false) }
     var isDescriptionExpanded by remember { mutableStateOf(false) }
     var showRatingPicker by remember { mutableStateOf(false) }
     var showReviewsDropdown by remember { mutableStateOf(false) }
 
     // Check if this audiobook is currently playing or loaded
-    val currentAudiobook by viewModel.playerState.currentAudiobook.collectAsState()
-    val isPlaying by viewModel.playerState.isPlaying.collectAsState()
-    val currentPosition by viewModel.playerState.currentPosition.collectAsState()
+    val currentAudiobook by viewModel.playerState.currentAudiobook.collectAsStateWithLifecycle()
+    val isPlaying by viewModel.playerState.isPlaying.collectAsStateWithLifecycle()
+    val currentPosition by viewModel.playerState.currentPosition.collectAsStateWithLifecycle()
     val isThisBookLoaded = currentAudiobook?.id == audiobookId
     val isThisBookPlaying = isThisBookLoaded && isPlaying
 
     // Download state
-    val downloadStates by viewModel.downloadManager.downloadStates.collectAsState()
+    val downloadStates by viewModel.downloadStates.collectAsStateWithLifecycle()
     val downloadState = downloadStates[audiobookId]
-    val isDownloaded = viewModel.downloadManager.isDownloaded(audiobookId)
+    val isDownloaded = viewModel.isDownloaded(audiobookId)
     val isDownloading = downloadState?.isDownloading == true
     val downloadProgress = downloadState?.progress ?: 0f
     val downloadError = downloadState?.error

--- a/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/detail/AudiobookDetailViewModel.kt
@@ -9,10 +9,7 @@ import com.sappho.audiobooks.data.remote.AudiobookUpdateRequest
 import com.sappho.audiobooks.data.remote.AverageRating
 import com.sappho.audiobooks.data.remote.ChapterUpdate
 import com.sappho.audiobooks.data.remote.ChapterUpdateRequest
-import com.sappho.audiobooks.data.remote.AddToCollectionRequest
 import com.sappho.audiobooks.data.remote.Collection
-import com.sappho.audiobooks.data.remote.CollectionForBook
-import com.sappho.audiobooks.data.remote.CreateCollectionRequest
 import com.sappho.audiobooks.data.remote.FetchChaptersRequest
 import com.sappho.audiobooks.data.remote.MetadataSearchResult
 import com.sappho.audiobooks.data.remote.RatingRequest
@@ -29,6 +26,7 @@ import com.sappho.audiobooks.service.DownloadService
 import com.sappho.audiobooks.service.PlayerState
 import com.sappho.audiobooks.download.DownloadManager
 import com.sappho.audiobooks.util.NetworkMonitor
+import com.sappho.audiobooks.util.parseApiErrorMessage
 import com.sappho.audiobooks.domain.model.ConversionJob
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -47,13 +45,19 @@ class AudiobookDetailViewModel @Inject constructor(
     private val api: SapphoApi,
     private val authRepository: AuthRepository,
     val playerState: PlayerState,
-    val downloadManager: DownloadManager,
+    private val downloadManager: DownloadManager,
     private val networkMonitor: NetworkMonitor
 ) : ViewModel() {
 
     companion object {
         private const val TAG = "AudiobookDetailVM"
     }
+
+    // Expose only the download state the UI needs — not the manager itself
+    val downloadStates: StateFlow<Map<Int, com.sappho.audiobooks.download.DownloadState>> =
+        downloadManager.downloadStates
+
+    fun isDownloaded(audiobookId: Int): Boolean = downloadManager.isDownloaded(audiobookId)
 
     private val _audiobook = MutableStateFlow<Audiobook?>(null)
     val audiobook: StateFlow<Audiobook?> = _audiobook
@@ -144,14 +148,21 @@ class AudiobookDetailViewModel @Inject constructor(
     private val _fetchChaptersResult = MutableStateFlow<String?>(null)
     val fetchChaptersResult: StateFlow<String?> = _fetchChaptersResult
 
-    private val _collections = MutableStateFlow<List<Collection>>(emptyList())
-    val collections: StateFlow<List<Collection>> = _collections
+    // Collection picker state and actions shared with other screens (L3 dedup)
+    private val bookCollectionsController =
+        com.sappho.audiobooks.presentation.components.BookCollectionsController(api, viewModelScope, TAG)
+    val collections: StateFlow<List<Collection>> = bookCollectionsController.collections
+    val bookCollections: StateFlow<Set<Int>> = bookCollectionsController.bookCollections
+    val isLoadingCollections: StateFlow<Boolean> = bookCollectionsController.isLoadingCollections
 
-    private val _bookCollections = MutableStateFlow<Set<Int>>(emptySet())
-    val bookCollections: StateFlow<Set<Int>> = _bookCollections
+    fun loadCollectionsForBook(bookId: Int) =
+        bookCollectionsController.loadCollectionsForBook(bookId)
 
-    private val _isLoadingCollections = MutableStateFlow(false)
-    val isLoadingCollections: StateFlow<Boolean> = _isLoadingCollections
+    fun toggleBookInCollection(collectionId: Int, bookId: Int) =
+        bookCollectionsController.toggleBookInCollection(collectionId, bookId)
+
+    fun createCollectionAndAddBook(name: String, bookId: Int, isPublic: Boolean = false) =
+        bookCollectionsController.createCollectionAndAddBook(name, bookId, isPublic)
 
     // AI Recap (Catch Up)
     private val _isAiConfigured = MutableStateFlow(false)
@@ -466,11 +477,7 @@ class AudiobookDetailViewModel @Inject constructor(
                             _isConverting.value = false
                         }
                     } else {
-                        val errorBody = response.errorBody()?.string()
-                        val errorMessage = try {
-                            val jsonError = com.google.gson.JsonParser.parseString(errorBody).asJsonObject
-                            jsonError.get("error")?.asString
-                        } catch (e: Exception) { null }
+                        val errorMessage = parseApiErrorMessage(response)
                         _convertResult.value = "Failed to convert: ${errorMessage ?: "Unknown error"}"
                         _isConverting.value = false
                     }
@@ -793,15 +800,7 @@ class AudiobookDetailViewModel @Inject constructor(
                         // Reload audiobook to refresh any updated data
                         loadAudiobook(book.id)
                     } else {
-                        // Try to parse error message from server response
-                        val errorBody = response.errorBody()?.string()
-                        val errorMessage = try {
-                            // Server may return JSON with error field
-                            val jsonError = com.google.gson.JsonParser.parseString(errorBody).asJsonObject
-                            jsonError.get("error")?.asString ?: jsonError.get("message")?.asString
-                        } catch (e: Exception) {
-                            null
-                        }
+                        val errorMessage = parseApiErrorMessage(response)
 
                         _embedMetadataResult.value = when {
                             response.code() == 500 && errorMessage != null -> "Server error: $errorMessage"
@@ -865,7 +864,6 @@ class AudiobookDetailViewModel @Inject constructor(
                         loadAudiobook(book.id)
                         onSuccess()
                     } else {
-                        val errorBody = response.errorBody()?.string()
                         _fetchChaptersResult.value = when (response.code()) {
                             404 -> "No chapters found for this ASIN"
                             else -> "Failed to fetch chapters: ${response.code()}"
@@ -888,79 +886,6 @@ class AudiobookDetailViewModel @Inject constructor(
 
     fun clearFetchChaptersResult() {
         _fetchChaptersResult.value = null
-    }
-
-    fun loadCollectionsForBook(bookId: Int) {
-        viewModelScope.launch {
-            _isLoadingCollections.value = true
-            try {
-                // Load all collections and which ones contain this book in parallel
-                val collectionsResponse = api.getCollections()
-                val bookCollectionsResponse = api.getCollectionsForBook(bookId)
-
-                if (collectionsResponse.isSuccessful) {
-                    _collections.value = collectionsResponse.body() ?: emptyList()
-                }
-                if (bookCollectionsResponse.isSuccessful) {
-                    _bookCollections.value = (bookCollectionsResponse.body() ?: emptyList())
-                        .filter { it.containsBook == 1 }
-                        .map { it.id }
-                        .toSet()
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to load collections for book", e)
-            } finally {
-                _isLoadingCollections.value = false
-            }
-        }
-    }
-
-    fun toggleBookInCollection(collectionId: Int, bookId: Int) {
-        viewModelScope.launch {
-            val isInCollection = _bookCollections.value.contains(collectionId)
-            try {
-                if (isInCollection) {
-                    val response = api.removeFromCollection(collectionId, bookId)
-                    if (response.isSuccessful) {
-                        _bookCollections.value = _bookCollections.value - collectionId
-                    }
-                } else {
-                    val response = api.addToCollection(collectionId, AddToCollectionRequest(bookId))
-                    if (response.isSuccessful) {
-                        _bookCollections.value = _bookCollections.value + collectionId
-                    }
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to toggle book in collection", e)
-            }
-        }
-    }
-
-    fun createCollectionAndAddBook(name: String, bookId: Int, isPublic: Boolean = false) {
-        viewModelScope.launch {
-            try {
-                val createResponse = api.createCollection(CreateCollectionRequest(name, null, isPublic))
-                if (createResponse.isSuccessful) {
-                    val newCollection = createResponse.body()
-                    if (newCollection != null) {
-                        // Add book to the new collection
-                        val addResponse = api.addToCollection(newCollection.id, AddToCollectionRequest(bookId))
-                        if (addResponse.isSuccessful) {
-                            _collections.value = listOf(newCollection) + _collections.value
-                            _bookCollections.value = _bookCollections.value + newCollection.id
-                        }
-                    }
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to create collection and add book", e)
-            }
-        }
     }
 
     private val _isDeletingFile = MutableStateFlow(false)
@@ -989,13 +914,7 @@ class AudiobookDetailViewModel @Inject constructor(
                         // File was deleted, but refresh failed - still ok
                     }
                 } else {
-                    val errorBody = response.errorBody()?.string()
-                    val errorMessage = try {
-                        val jsonError = com.google.gson.JsonParser.parseString(errorBody).asJsonObject
-                        jsonError.get("error")?.asString
-                    } catch (e: Exception) {
-                        null
-                    }
+                    val errorMessage = parseApiErrorMessage(response)
                     _deleteFileError.value = errorMessage ?: "Failed to delete file"
                 }
             } catch (e: CancellationException) {
@@ -1038,13 +957,7 @@ class AudiobookDetailViewModel @Inject constructor(
                     if (response.isSuccessful) {
                         _recap.value = response.body()
                     } else {
-                        val errorBody = response.errorBody()?.string()
-                        val errorMessage = try {
-                            val jsonError = com.google.gson.JsonParser.parseString(errorBody).asJsonObject
-                            jsonError.get("error")?.asString ?: jsonError.get("message")?.asString
-                        } catch (e: Exception) {
-                            null
-                        }
+                        val errorMessage = parseApiErrorMessage(response)
                         _recapError.value = errorMessage ?: "Failed to load recap"
                     }
                 } catch (e: CancellationException) {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Brush
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sappho.audiobooks.presentation.theme.SapphoAnimatedVisibility
 import com.sappho.audiobooks.presentation.theme.bouncyClickable
 import com.sappho.audiobooks.presentation.theme.accessibleCard
@@ -70,21 +71,21 @@ fun HomeScreen(
     onAudiobookClick: (Int) -> Unit = {},
     viewModel: HomeViewModel = hiltViewModel()
 ) {
-    val inProgress by viewModel.inProgress.collectAsState()
-    val upNext by viewModel.upNext.collectAsState()
-    val recentlyAdded by viewModel.recentlyAdded.collectAsState()
-    val finished by viewModel.finished.collectAsState()
-    val isLoading by viewModel.isLoading.collectAsState()
-    val serverUrl by viewModel.serverUrl.collectAsState()
-    val isOffline by viewModel.isOffline.collectAsState()
-    val downloadedBooks by viewModel.downloadedBooks.collectAsState()
-    val downloadStates by viewModel.downloadStates.collectAsState()
-    val syncStatus by viewModel.syncStatus.collectAsState()
+    val inProgress by viewModel.inProgress.collectAsStateWithLifecycle()
+    val upNext by viewModel.upNext.collectAsStateWithLifecycle()
+    val recentlyAdded by viewModel.recentlyAdded.collectAsStateWithLifecycle()
+    val finished by viewModel.finished.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val serverUrl by viewModel.serverUrl.collectAsStateWithLifecycle()
+    val isOffline by viewModel.isOffline.collectAsStateWithLifecycle()
+    val downloadedBooks by viewModel.downloadedBooks.collectAsStateWithLifecycle()
+    val downloadStates by viewModel.downloadStates.collectAsStateWithLifecycle()
+    val syncStatus by viewModel.syncStatus.collectAsStateWithLifecycle()
 
     // Collections state
-    val collections by viewModel.collections.collectAsState()
-    val bookCollections by viewModel.bookCollections.collectAsState()
-    val isLoadingCollections by viewModel.isLoadingCollections.collectAsState()
+    val collections by viewModel.collections.collectAsStateWithLifecycle()
+    val bookCollections by viewModel.bookCollections.collectAsStateWithLifecycle()
+    val isLoadingCollections by viewModel.isLoadingCollections.collectAsStateWithLifecycle()
 
     // Dialog state
     var showCollectionDialog by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/home/HomeViewModel.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sappho.audiobooks.data.remote.SapphoApi
 import com.sappho.audiobooks.data.remote.Collection
-import com.sappho.audiobooks.data.remote.AddToCollectionRequest
-import com.sappho.audiobooks.data.remote.CreateCollectionRequest
 import com.sappho.audiobooks.data.repository.AuthRepository
 import com.sappho.audiobooks.domain.model.Audiobook
 import com.sappho.audiobooks.download.DownloadManager
@@ -72,14 +70,21 @@ class HomeViewModel @Inject constructor(
         downloadManager.downloadStates
 
     // Collections state
-    private val _collections = MutableStateFlow<List<Collection>>(emptyList())
-    val collections: StateFlow<List<Collection>> = _collections
+    // Collection picker state and actions shared with other screens (L3 dedup)
+    private val bookCollectionsController =
+        com.sappho.audiobooks.presentation.components.BookCollectionsController(api, viewModelScope, TAG)
+    val collections: StateFlow<List<Collection>> = bookCollectionsController.collections
+    val bookCollections: StateFlow<Set<Int>> = bookCollectionsController.bookCollections
+    val isLoadingCollections: StateFlow<Boolean> = bookCollectionsController.isLoadingCollections
 
-    private val _bookCollections = MutableStateFlow<Set<Int>>(emptySet())
-    val bookCollections: StateFlow<Set<Int>> = _bookCollections
+    fun loadCollectionsForBook(bookId: Int) =
+        bookCollectionsController.loadCollectionsForBook(bookId)
 
-    private val _isLoadingCollections = MutableStateFlow(false)
-    val isLoadingCollections: StateFlow<Boolean> = _isLoadingCollections
+    fun toggleBookInCollection(collectionId: Int, bookId: Int) =
+        bookCollectionsController.toggleBookInCollection(collectionId, bookId)
+
+    fun createCollectionAndAddBook(name: String, bookId: Int, isPublic: Boolean = false) =
+        bookCollectionsController.createCollectionAndAddBook(name, bookId, isPublic)
 
     init {
         _serverUrl.value = authRepository.getServerUrlSync()
@@ -280,76 +285,6 @@ class HomeViewModel @Inject constructor(
     }
 
     // Collection functions
-    fun loadCollectionsForBook(bookId: Int) {
-        viewModelScope.launch {
-            _isLoadingCollections.value = true
-            try {
-                val collectionsResponse = api.getCollections()
-                val bookCollectionsResponse = api.getCollectionsForBook(bookId)
-
-                if (collectionsResponse.isSuccessful) {
-                    _collections.value = collectionsResponse.body() ?: emptyList()
-                }
-                if (bookCollectionsResponse.isSuccessful) {
-                    _bookCollections.value = (bookCollectionsResponse.body() ?: emptyList())
-                        .filter { it.containsBook == 1 }
-                        .map { it.id }
-                        .toSet()
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to load collections for book", e)
-            } finally {
-                _isLoadingCollections.value = false
-            }
-        }
-    }
-
-    fun toggleBookInCollection(collectionId: Int, bookId: Int) {
-        viewModelScope.launch {
-            val isInCollection = _bookCollections.value.contains(collectionId)
-            try {
-                if (isInCollection) {
-                    val response = api.removeFromCollection(collectionId, bookId)
-                    if (response.isSuccessful) {
-                        _bookCollections.value = _bookCollections.value - collectionId
-                    }
-                } else {
-                    val response = api.addToCollection(collectionId, AddToCollectionRequest(bookId))
-                    if (response.isSuccessful) {
-                        _bookCollections.value = _bookCollections.value + collectionId
-                    }
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to toggle book in collection", e)
-            }
-        }
-    }
-
-    fun createCollectionAndAddBook(name: String, bookId: Int, isPublic: Boolean = false) {
-        viewModelScope.launch {
-            try {
-                val createResponse = api.createCollection(CreateCollectionRequest(name, null, isPublic))
-                if (createResponse.isSuccessful) {
-                    val newCollection = createResponse.body()
-                    if (newCollection != null) {
-                        val addResponse = api.addToCollection(newCollection.id, AddToCollectionRequest(bookId))
-                        if (addResponse.isSuccessful) {
-                            _collections.value = listOf(newCollection) + _collections.value
-                            _bookCollections.value = _bookCollections.value + newCollection.id
-                        }
-                    }
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to create collection and add book", e)
-            }
-        }
-    }
     
     fun triggerManualSync() {
         syncStatusManager.triggerSync()

--- a/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.sappho.audiobooks.presentation.theme.*
 import androidx.compose.animation.core.Spring
@@ -153,13 +154,13 @@ fun LibraryScreen(
     initialSeries: String? = null,
     viewModel: LibraryViewModel = hiltViewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
-    val series by viewModel.series.collectAsState()
-    val authors by viewModel.authors.collectAsState()
-    val genres by viewModel.genres.collectAsState()
-    val allBooks by viewModel.allAudiobooks.collectAsState()
-    val collections by viewModel.collections.collectAsState()
-    val readingList by viewModel.readingList.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val series by viewModel.series.collectAsStateWithLifecycle()
+    val authors by viewModel.authors.collectAsStateWithLifecycle()
+    val genres by viewModel.genres.collectAsStateWithLifecycle()
+    val allBooks by viewModel.allAudiobooks.collectAsStateWithLifecycle()
+    val collections by viewModel.collections.collectAsStateWithLifecycle()
+    val readingList by viewModel.readingList.collectAsStateWithLifecycle()
 
     // Refresh data when screen is loaded to get latest progress
     LaunchedEffect(Unit) {
@@ -223,7 +224,7 @@ fun LibraryScreen(
                 SeriesListView(
                     series = series,
                     allBooks = allBooks,
-                    serverUrl = viewModel.serverUrl.collectAsState().value,
+                    serverUrl = viewModel.serverUrl.collectAsStateWithLifecycle().value,
                     onBackClick = { currentViewName = LibraryView.CATEGORIES.name },
                     onSeriesClick = { seriesName ->
                         selectedSeries = seriesName
@@ -242,8 +243,8 @@ fun LibraryScreen(
                         books = seriesBooks,
                         totalDuration = totalDuration,
                         authors = bookAuthors,
-                        serverUrl = viewModel.serverUrl.collectAsState().value,
-                        aiConfigured = viewModel.aiConfigured.collectAsState().value,
+                        serverUrl = viewModel.serverUrl.collectAsStateWithLifecycle().value,
+                        aiConfigured = viewModel.aiConfigured.collectAsStateWithLifecycle().value,
                         viewModel = viewModel,
                         onBackClick = { currentViewName = LibraryView.SERIES.name },
                         onBookClick = onAudiobookClick
@@ -254,7 +255,7 @@ fun LibraryScreen(
                 AuthorsListView(
                     authors = authors,
                     allBooks = allBooks,
-                    serverUrl = viewModel.serverUrl.collectAsState().value,
+                    serverUrl = viewModel.serverUrl.collectAsStateWithLifecycle().value,
                     onBackClick = { currentViewName = LibraryView.CATEGORIES.name },
                     onAuthorClick = { author ->
                         selectedAuthor = author
@@ -269,7 +270,7 @@ fun LibraryScreen(
                     AuthorBooksView(
                         authorName = authorName,
                         books = authorBooks,
-                        serverUrl = viewModel.serverUrl.collectAsState().value,
+                        serverUrl = viewModel.serverUrl.collectAsStateWithLifecycle().value,
                         onBackClick = { currentViewName = LibraryView.AUTHORS.name },
                         onBookClick = onAudiobookClick
                     )
@@ -279,7 +280,7 @@ fun LibraryScreen(
                 GenresListView(
                     genres = genres.map { it.genre },
                     allBooks = allBooks,
-                    serverUrl = viewModel.serverUrl.collectAsState().value,
+                    serverUrl = viewModel.serverUrl.collectAsStateWithLifecycle().value,
                     onBackClick = { currentViewName = LibraryView.CATEGORIES.name },
                     onGenreClick = { genre ->
                         selectedGenre = genre
@@ -295,7 +296,7 @@ fun LibraryScreen(
                     GenreBooksView(
                         genreName = genreName,
                         books = genreBooks,
-                        serverUrl = viewModel.serverUrl.collectAsState().value,
+                        serverUrl = viewModel.serverUrl.collectAsStateWithLifecycle().value,
                         onBackClick = { currentViewName = LibraryView.GENRES.name },
                         onBookClick = onAudiobookClick
                     )
@@ -3102,14 +3103,14 @@ fun AllBooksView(
     onAudiobookClick: (Int) -> Unit = {},
     isAdmin: Boolean = false
 ) {
-    val allBooks by viewModel.allAudiobooks.collectAsState()
-    val serverUrl by viewModel.serverUrl.collectAsState()
-    val sortOption by viewModel.userPreferences.librarySortOption.collectAsState()
-    val sortAscending by viewModel.userPreferences.librarySortAscending.collectAsState()
-    val filterOption by viewModel.userPreferences.libraryFilterOption.collectAsState()
-    val isSelectionMode by viewModel.isSelectionMode.collectAsState()
-    val selectedBookIds by viewModel.selectedBookIds.collectAsState()
-    val collections by viewModel.collections.collectAsState()
+    val allBooks by viewModel.allAudiobooks.collectAsStateWithLifecycle()
+    val serverUrl by viewModel.serverUrl.collectAsStateWithLifecycle()
+    val sortOption by viewModel.userPreferences.librarySortOption.collectAsStateWithLifecycle()
+    val sortAscending by viewModel.userPreferences.librarySortAscending.collectAsStateWithLifecycle()
+    val filterOption by viewModel.userPreferences.libraryFilterOption.collectAsStateWithLifecycle()
+    val isSelectionMode by viewModel.isSelectionMode.collectAsStateWithLifecycle()
+    val selectedBookIds by viewModel.selectedBookIds.collectAsStateWithLifecycle()
+    val collections by viewModel.collections.collectAsStateWithLifecycle()
 
     var showBatchCollectionDialog by remember { mutableStateOf(false) }
     var showDeleteConfirmDialog by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/library/LibraryViewModel.kt
@@ -11,6 +11,7 @@ import com.sappho.audiobooks.domain.model.GenreInfo
 import com.sappho.audiobooks.domain.model.GenreMetadata
 import com.sappho.audiobooks.domain.model.SeriesInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -144,6 +145,8 @@ class LibraryViewModel @Inject constructor(
                     _aiConfigured.value = response.body()?.configured ?: false
                     Log.d("LibraryViewModel", "AI configured: ${_aiConfigured.value}")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error checking AI status", e)
                 _aiConfigured.value = false
@@ -163,6 +166,8 @@ class LibraryViewModel @Inject constructor(
                 val errorBody = response.errorBody()?.string()
                 Result.failure(Exception(errorBody ?: "Failed to get recap"))
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e("LibraryViewModel", "Error getting series recap", e)
             Result.failure(e)
@@ -179,6 +184,8 @@ class LibraryViewModel @Inject constructor(
             } else {
                 Result.failure(Exception("Failed to clear recap cache"))
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e("LibraryViewModel", "Error clearing series recap", e)
             Result.failure(e)
@@ -200,6 +207,8 @@ class LibraryViewModel @Inject constructor(
                     _readingList.value = response.body() ?: emptyList()
                     Log.d("LibraryViewModel", "Loaded ${_readingList.value.size} reading list items")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error loading reading list", e)
             }
@@ -215,6 +224,8 @@ class LibraryViewModel @Inject constructor(
                     _collections.value = response.body() ?: emptyList()
                     Log.d("LibraryViewModel", "Loaded ${_collections.value.size} collections")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error loading collections", e)
             }
@@ -228,6 +239,8 @@ class LibraryViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _selectedCollection.value = response.body()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error loading collection detail", e)
             }
@@ -248,6 +261,8 @@ class LibraryViewModel @Inject constructor(
                 } else {
                     onResult(false, "Failed to create collection")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error creating collection", e)
                 onResult(false, e.message ?: "Error creating collection")
@@ -266,6 +281,8 @@ class LibraryViewModel @Inject constructor(
                 } else {
                     onResult(false, "Failed to update collection")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error updating collection", e)
                 onResult(false, e.message ?: "Error updating collection")
@@ -286,6 +303,8 @@ class LibraryViewModel @Inject constructor(
                 } else {
                     onResult(false, "Failed to delete collection")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error deleting collection", e)
                 onResult(false, e.message ?: "Error deleting collection")
@@ -312,6 +331,8 @@ class LibraryViewModel @Inject constructor(
                     }
                     onResult(false, errorMessage)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error adding to collection", e)
                 onResult(false, e.message ?: "Error adding to collection")
@@ -330,6 +351,8 @@ class LibraryViewModel @Inject constructor(
                 } else {
                     onResult(false, "Failed to remove from collection")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error removing from collection", e)
                 onResult(false, e.message ?: "Error removing from collection")
@@ -344,6 +367,8 @@ class LibraryViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _collectionsForBook.value = response.body() ?: emptyList()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error loading collections for book", e)
             }
@@ -398,6 +423,8 @@ class LibraryViewModel @Inject constructor(
                 } else {
                     onResult(false, "Failed to mark books as finished")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error in batch mark finished", e)
                 onResult(false, e.message ?: "Error marking books finished")
@@ -418,6 +445,8 @@ class LibraryViewModel @Inject constructor(
                 } else {
                     onResult(false, "Failed to clear progress")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error in batch clear progress", e)
                 onResult(false, e.message ?: "Error clearing progress")
@@ -438,6 +467,8 @@ class LibraryViewModel @Inject constructor(
                 } else {
                     onResult(false, "Failed to add to reading list")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error in batch add to reading list", e)
                 onResult(false, e.message ?: "Error adding to reading list")
@@ -474,6 +505,8 @@ class LibraryViewModel @Inject constructor(
                 } else {
                     onResult(true, "Deleted $totalDeleted books (${errors.size} batch(es) failed)")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error in batch delete", e)
                 onResult(false, e.message ?: "Error deleting books")
@@ -516,6 +549,8 @@ class LibraryViewModel @Inject constructor(
                         onResult(false, "Failed to add to collection")
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error in batch add to collection", e)
                 onResult(false, e.message ?: "Error adding to collection")
@@ -571,11 +606,15 @@ class LibraryViewModel @Inject constructor(
                     } else {
                         Log.e("LibraryViewModel", "Audiobooks request failed: ${audiobooksResponse.code()} - ${audiobooksResponse.errorBody()?.string()}")
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Log.e("LibraryViewModel", "Error loading audiobooks", e)
                 }
 
                 _uiState.value = LibraryUiState.Success
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("LibraryViewModel", "Error loading categories", e)
                 _uiState.value = LibraryUiState.Error(e.message ?: "Unknown error")

--- a/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/login/LoginScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sappho.audiobooks.presentation.theme.*
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
@@ -45,8 +46,8 @@ fun LoginScreen(
     var password by remember { mutableStateOf("") }
     var passwordVisible by remember { mutableStateOf(false) }
     var mfaCode by remember { mutableStateOf("") }
-    val serverUrl by viewModel.serverUrl.collectAsState()
-    val uiState by viewModel.uiState.collectAsState()
+    val serverUrl by viewModel.serverUrl.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val focusManager = LocalFocusManager.current
 
     // Navigate on success

--- a/app/src/main/java/com/sappho/audiobooks/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/main/MainScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sappho.audiobooks.presentation.theme.*
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
@@ -140,11 +141,11 @@ fun MainScreen(
         }
     }
     var showUserMenu by remember { mutableStateOf(false) }
-    val user by viewModel.user.collectAsState()
-    val serverUrl by viewModel.serverUrl.collectAsState()
-    val serverVersion by viewModel.serverVersion.collectAsState()
-    val cachedAvatarFile by viewModel.cachedAvatarFile.collectAsState()
-    val currentAudiobook by viewModel.playerState.currentAudiobook.collectAsState()
+    val user by viewModel.user.collectAsStateWithLifecycle()
+    val serverUrl by viewModel.serverUrl.collectAsStateWithLifecycle()
+    val serverVersion by viewModel.serverVersion.collectAsStateWithLifecycle()
+    val cachedAvatarFile by viewModel.cachedAvatarFile.collectAsStateWithLifecycle()
+    val currentAudiobook by viewModel.playerState.currentAudiobook.collectAsStateWithLifecycle()
     val context = androidx.compose.ui.platform.LocalContext.current
 
     var showCastDialog by remember { mutableStateOf(false) }
@@ -152,13 +153,12 @@ fun MainScreen(
     var showUploadDialog by remember { mutableStateOf(false) }
     var downloadToDelete by remember { mutableStateOf<Int?>(null) }
     val castHelper = viewModel.castHelper
-    val downloadManager = viewModel.downloadManager
-    val downloadedBooks by downloadManager.downloadedBooks.collectAsState()
+    val downloadedBooks by viewModel.downloadedBooks.collectAsStateWithLifecycle()
 
     // Notification state
     var showNotificationPanel by remember { mutableStateOf(false) }
-    val unreadNotificationCount by viewModel.unreadNotificationCount.collectAsState()
-    val notifications by viewModel.notifications.collectAsState()
+    val unreadNotificationCount by viewModel.unreadNotificationCount.collectAsStateWithLifecycle()
+    val notifications by viewModel.notifications.collectAsStateWithLifecycle()
 
     // Check if we should show navigation rail (tablets/landscape)
     val useNavigationRail = shouldShowNavigationRail()
@@ -465,7 +465,7 @@ fun MainScreen(
         // Cast Dialog
         if (showCastDialog) {
             val isCasting = castHelper.isCasting()
-            val availableRoutes by castHelper.availableRoutes.collectAsState()
+            val availableRoutes by castHelper.availableRoutes.collectAsStateWithLifecycle()
             var isScanning by remember { mutableStateOf(true) }
 
             // Start discovery and clean up when dialog closes
@@ -792,7 +792,7 @@ fun MainScreen(
                     TextButton(
                         onClick = {
                             downloadToDelete?.let { id ->
-                                downloadManager.deleteDownload(id)
+                                viewModel.deleteDownload(id)
                             }
                             downloadToDelete = null
                         }
@@ -826,9 +826,9 @@ private fun UploadDialog(
     onDismiss: () -> Unit
 ) {
     val context = androidx.compose.ui.platform.LocalContext.current
-    val uploadState by viewModel.uploadState.collectAsState()
-    val uploadProgress by viewModel.uploadProgress.collectAsState()
-    val uploadResult by viewModel.uploadResult.collectAsState()
+    val uploadState by viewModel.uploadState.collectAsStateWithLifecycle()
+    val uploadProgress by viewModel.uploadProgress.collectAsStateWithLifecycle()
+    val uploadResult by viewModel.uploadResult.collectAsStateWithLifecycle()
 
     var selectedFiles by remember { mutableStateOf<List<Uri>>(emptyList()) }
     var title by remember { mutableStateOf("") }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/main/MainViewModel.kt
@@ -12,6 +12,7 @@ import com.sappho.audiobooks.service.UploadService
 import com.sappho.audiobooks.service.UploadServiceState
 import com.sappho.audiobooks.service.UploadStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -38,8 +39,12 @@ class MainViewModel @Inject constructor(
     private val okHttpClient: OkHttpClient,
     val playerState: com.sappho.audiobooks.service.PlayerState,
     val castHelper: com.sappho.audiobooks.cast.CastHelper,
-    val downloadManager: com.sappho.audiobooks.download.DownloadManager
+    private val downloadManager: com.sappho.audiobooks.download.DownloadManager
 ) : ViewModel() {
+
+    // Expose only the download state the UI needs — not the manager itself
+    val downloadedBooks: StateFlow<List<com.sappho.audiobooks.download.DownloadedBook>> =
+        downloadManager.downloadedBooks
 
     private val _user = MutableStateFlow<User?>(null)
     val user: StateFlow<User?> = _user
@@ -144,6 +149,8 @@ class MainViewModel @Inject constructor(
                     }
                 } else {
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 // Offline - keep using cached user
 
@@ -178,6 +185,8 @@ class MainViewModel @Inject constructor(
                         }
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("MainViewModel", "Error caching avatar", e)
             }
@@ -191,6 +200,8 @@ class MainViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _serverVersion.value = response.body()?.version
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 // Ignore errors - version is optional
             }
@@ -216,6 +227,10 @@ class MainViewModel @Inject constructor(
             kotlinx.coroutines.delay(1500)
             loadUser()
         }
+    }
+
+    fun deleteDownload(audiobookId: Int) {
+        downloadManager.deleteDownload(audiobookId)
     }
 
     fun clearUploadResult() {
@@ -263,6 +278,8 @@ class MainViewModel @Inject constructor(
                     if (response.isSuccessful) {
                         _unreadNotificationCount.value = response.body()?.count ?: 0
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (_: Exception) {
                     // Ignore errors - notification count is non-critical
                 }
@@ -278,6 +295,8 @@ class MainViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _notifications.value = response.body() ?: emptyList()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Exception) {
                 // Ignore errors
             }
@@ -296,6 +315,8 @@ class MainViewModel @Inject constructor(
                     _unreadNotificationCount.value =
                         (_unreadNotificationCount.value - 1).coerceAtLeast(0)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Exception) {
                 // Ignore errors
             }
@@ -312,6 +333,8 @@ class MainViewModel @Inject constructor(
                     }
                     _unreadNotificationCount.value = 0
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Exception) {
                 // Ignore errors
             }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/MinimizedPlayerBar.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/MinimizedPlayerBar.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sappho.audiobooks.presentation.theme.*
 import com.sappho.audiobooks.presentation.theme.Timing
 import androidx.compose.ui.graphics.graphicsLayer
@@ -55,15 +56,15 @@ fun MinimizedPlayerBar(
     onExpand: () -> Unit,
     onRestartPlayback: (audiobookId: Int, position: Int) -> Unit = { _, _ -> }
 ) {
-    val audiobook by playerState.currentAudiobook.collectAsState()
-    val localIsPlaying by playerState.isPlaying.collectAsState()
-    val localPosition by playerState.currentPosition.collectAsState()
-    val duration by playerState.duration.collectAsState()
-    val bufferedPosition by playerState.bufferedPosition.collectAsState()
+    val audiobook by playerState.currentAudiobook.collectAsStateWithLifecycle()
+    val localIsPlaying by playerState.isPlaying.collectAsStateWithLifecycle()
+    val localPosition by playerState.currentPosition.collectAsStateWithLifecycle()
+    val duration by playerState.duration.collectAsStateWithLifecycle()
+    val bufferedPosition by playerState.bufferedPosition.collectAsStateWithLifecycle()
 
     // Check cast state - use reactive StateFlow
-    val isCastConnected by castHelper.isConnected.collectAsState()
-    val castIsPlaying by castHelper.isPlayingFlow.collectAsState()
+    val isCastConnected by castHelper.isConnected.collectAsStateWithLifecycle()
+    val castIsPlaying by castHelper.isPlayingFlow.collectAsStateWithLifecycle()
     val isPlaying = if (isCastConnected) castIsPlaying else localIsPlaying
 
     // Poll Cast position when connected for smooth time updates

--- a/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/player/PlayerActivity.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sappho.audiobooks.presentation.theme.*
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
@@ -136,10 +137,10 @@ fun PlayerScreen(
 ) {
     val context = LocalContext.current
     val haptic = LocalHapticFeedback.current
-    val audiobook by viewModel.audiobook.collectAsState()
-    val chapters by viewModel.chapters.collectAsState()
-    val playerState by viewModel.playerState.collectAsState()
-    val serverUrl by viewModel.serverUrl.collectAsState()
+    val audiobook by viewModel.audiobook.collectAsStateWithLifecycle()
+    val chapters by viewModel.chapters.collectAsStateWithLifecycle()
+    val playerState by viewModel.playerState.collectAsStateWithLifecycle()
+    val serverUrl by viewModel.serverUrl.collectAsStateWithLifecycle()
     var showChapters by remember { mutableStateOf(false) }
     var showPlaybackSpeed by remember { mutableStateOf(false) }
     var showSleepTimer by remember { mutableStateOf(false) }
@@ -171,22 +172,22 @@ fun PlayerScreen(
     }
 
     // Determine playing state based on whether we're casting or using local playback
-    val localIsPlaying = playerState?.isPlaying?.collectAsState()?.value ?: false
-    val castIsPlaying = castManager.isPlaying.collectAsState().value
-    val isCastConnected = castManager.isConnected.collectAsState().value
-    val castError by castManager.castError.collectAsState()
+    val localIsPlaying = playerState?.isPlaying?.collectAsStateWithLifecycle()?.value ?: false
+    val castIsPlaying = castManager.isPlaying.collectAsStateWithLifecycle().value
+    val isCastConnected = castManager.isConnected.collectAsStateWithLifecycle().value
+    val castError by castManager.castError.collectAsStateWithLifecycle()
     val isPlaying = if (isCastConnected) {
         castIsPlaying
     } else {
         localIsPlaying
     }
-    val localPosition = playerState?.currentPosition?.collectAsState()?.value ?: 0L
-    val duration = playerState?.duration?.collectAsState()?.value ?: 0L
-    val isLoading = playerState?.isLoading?.collectAsState()?.value ?: false
-    val playbackSpeed = playerState?.playbackSpeed?.collectAsState()?.value ?: 1.0f
-    val sleepTimerRemaining = playerState?.sleepTimerRemaining?.collectAsState()?.value
-    val sleepAtEndOfChapter = playerState?.sleepAtEndOfChapter?.collectAsState()?.value ?: false
-    val playbackError = playerState?.playbackError?.collectAsState()?.value
+    val localPosition = playerState?.currentPosition?.collectAsStateWithLifecycle()?.value ?: 0L
+    val duration = playerState?.duration?.collectAsStateWithLifecycle()?.value ?: 0L
+    val isLoading = playerState?.isLoading?.collectAsStateWithLifecycle()?.value ?: false
+    val playbackSpeed = playerState?.playbackSpeed?.collectAsStateWithLifecycle()?.value ?: 1.0f
+    val sleepTimerRemaining = playerState?.sleepTimerRemaining?.collectAsStateWithLifecycle()?.value
+    val sleepAtEndOfChapter = playerState?.sleepAtEndOfChapter?.collectAsStateWithLifecycle()?.value ?: false
+    val playbackError = playerState?.playbackError?.collectAsStateWithLifecycle()?.value
 
     // When casting, poll the Cast position periodically
     var castPosition by remember { mutableLongStateOf(0L) }
@@ -1333,8 +1334,8 @@ fun PlayerScreen(
 
         // History dialog
         if (showHistory) {
-            val listeningSessions by viewModel.listeningSessions.collectAsState()
-            val historyLoading by viewModel.historyLoading.collectAsState()
+            val listeningSessions by viewModel.listeningSessions.collectAsStateWithLifecycle()
+            val historyLoading by viewModel.historyLoading.collectAsStateWithLifecycle()
 
             AlertDialog(
                 onDismissRequest = { showHistory = false },

--- a/app/src/main/java/com/sappho/audiobooks/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/profile/ProfileScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import coil.request.CachePolicy
 import coil.request.ImageRequest
@@ -51,15 +52,15 @@ fun ProfileScreen(
     viewModel: ProfileViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
-    val user by viewModel.user.collectAsState()
-    val stats by viewModel.stats.collectAsState()
-    val isLoading by viewModel.isLoading.collectAsState()
-    val isSaving by viewModel.isSaving.collectAsState()
-    val saveMessage by viewModel.saveMessage.collectAsState()
-    val serverUrl by viewModel.serverUrl.collectAsState()
-    val avatarUri by viewModel.avatarUri.collectAsState()
-    val serverVersion by viewModel.serverVersion.collectAsState()
-    val avatarUpdated by viewModel.avatarUpdated.collectAsState()
+    val user by viewModel.user.collectAsStateWithLifecycle()
+    val stats by viewModel.stats.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val isSaving by viewModel.isSaving.collectAsStateWithLifecycle()
+    val saveMessage by viewModel.saveMessage.collectAsStateWithLifecycle()
+    val serverUrl by viewModel.serverUrl.collectAsStateWithLifecycle()
+    val avatarUri by viewModel.avatarUri.collectAsStateWithLifecycle()
+    val serverVersion by viewModel.serverVersion.collectAsStateWithLifecycle()
+    val avatarUpdated by viewModel.avatarUpdated.collectAsStateWithLifecycle()
 
     val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/profile/ProfileViewModel.kt
@@ -10,6 +10,7 @@ import com.sappho.audiobooks.data.repository.UserPreferencesRepository
 import com.sappho.audiobooks.domain.model.User
 import com.sappho.audiobooks.domain.model.UserStats
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -86,6 +87,8 @@ class ProfileViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _user.value = response.body()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to load profile", e)
             } finally {
@@ -101,6 +104,8 @@ class ProfileViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _stats.value = response.body()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to load stats", e)
             }
@@ -114,6 +119,8 @@ class ProfileViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _serverVersion.value = response.body()?.version
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to load server version", e)
             }
@@ -132,6 +139,8 @@ class ProfileViewModel @Inject constructor(
                 } else {
                     _saveMessage.value = "Failed to update profile"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _saveMessage.value = "Error: ${e.message}"
             } finally {
@@ -181,6 +190,8 @@ class ProfileViewModel @Inject constructor(
                     val errorBody = response.errorBody()?.string()
                     _saveMessage.value = errorBody ?: "Failed to update profile"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _saveMessage.value = "Error: ${e.message}"
             } finally {
@@ -207,6 +218,8 @@ class ProfileViewModel @Inject constructor(
                 } else {
                     _saveMessage.value = "Failed to remove avatar"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _saveMessage.value = "Error: ${e.message}"
             } finally {
@@ -230,6 +243,8 @@ class ProfileViewModel @Inject constructor(
                         else -> errorBody ?: "Failed to update password"
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _saveMessage.value = "Error: ${e.message}"
             } finally {
@@ -259,6 +274,8 @@ class ProfileViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _users.value = response.body() ?: emptyList()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to load users", e)
             }
@@ -272,6 +289,8 @@ class ProfileViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _aiSettings.value = response.body()?.settings
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to load AI settings", e)
             }
@@ -288,6 +307,8 @@ class ProfileViewModel @Inject constructor(
                 } else {
                     onResult(false, "Failed to update AI settings")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 onResult(false, e.message ?: "Error updating settings")
             }
@@ -305,6 +326,8 @@ class ProfileViewModel @Inject constructor(
                     val errorBody = response.errorBody()?.string()
                     onResult(false, errorBody ?: "Connection failed")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 onResult(false, e.message ?: "Connection failed")
             }
@@ -324,6 +347,8 @@ class ProfileViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _scanResult.value = response.body()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to scan library", e)
             } finally {
@@ -343,6 +368,8 @@ class ProfileViewModel @Inject constructor(
                     val errorBody = response.errorBody()?.string()
                     onResult(false, errorBody ?: "Failed to create user")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 onResult(false, e.message ?: "Error creating user")
             }
@@ -360,6 +387,8 @@ class ProfileViewModel @Inject constructor(
                     val errorBody = response.errorBody()?.string()
                     onResult(false, errorBody ?: "Failed to delete user")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 onResult(false, e.message ?: "Error deleting user")
             }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/readinglist/ReadingListScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/readinglist/ReadingListScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.sappho.audiobooks.domain.model.Audiobook
 import com.sappho.audiobooks.presentation.theme.*
@@ -44,10 +45,10 @@ fun ReadingListScreen(
     onBackClick: () -> Unit = {},
     viewModel: ReadingListViewModel = hiltViewModel()
 ) {
-    val books by viewModel.books.collectAsState()
-    val isLoading by viewModel.isLoading.collectAsState()
-    val serverUrl by viewModel.serverUrl.collectAsState()
-    val sortOption by viewModel.sortOption.collectAsState()
+    val books by viewModel.books.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val serverUrl by viewModel.serverUrl.collectAsStateWithLifecycle()
+    val sortOption by viewModel.sortOption.collectAsStateWithLifecycle()
 
     BackHandler { onBackClick() }
 

--- a/app/src/main/java/com/sappho/audiobooks/presentation/readinglist/ReadingListViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/readinglist/ReadingListViewModel.kt
@@ -7,6 +7,7 @@ import com.sappho.audiobooks.data.remote.SapphoApi
 import com.sappho.audiobooks.data.repository.AuthRepository
 import com.sappho.audiobooks.domain.model.Audiobook
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -43,6 +44,8 @@ class ReadingListViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _books.value = response.body() ?: emptyList()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 // Silently handle network errors
             } finally {
@@ -67,6 +70,8 @@ class ReadingListViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 api.reorderFavorites(ReorderFavoritesRequest(current.map { it.id }))
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 // Silently handle sync failure; local state already updated optimistically
             }
@@ -80,6 +85,8 @@ class ReadingListViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 api.removeFavorite(audiobookId)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 // Revert on failure by reloading from server
                 loadReadingList()

--- a/app/src/main/java/com/sappho/audiobooks/presentation/search/SearchScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/search/SearchScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sappho.audiobooks.presentation.theme.*
 import com.sappho.audiobooks.presentation.theme.IconSize
 import com.sappho.audiobooks.presentation.theme.Spacing
@@ -39,10 +40,10 @@ fun SearchScreen(
     onAuthorClick: (String) -> Unit = {},
     viewModel: SearchViewModel = hiltViewModel()
 ) {
-    val searchQuery by viewModel.searchQuery.collectAsState()
-    val results by viewModel.results.collectAsState()
-    val isLoading by viewModel.isLoading.collectAsState()
-    val serverUrl by viewModel.serverUrl.collectAsState()
+    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
+    val results by viewModel.results.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val serverUrl by viewModel.serverUrl.collectAsStateWithLifecycle()
 
     val focusRequester = remember { FocusRequester() }
 

--- a/app/src/main/java/com/sappho/audiobooks/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/search/SearchViewModel.kt
@@ -6,6 +6,7 @@ import com.sappho.audiobooks.data.remote.SapphoApi
 import com.sappho.audiobooks.data.repository.AuthRepository
 import com.sappho.audiobooks.domain.model.Audiobook
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -132,6 +133,8 @@ class SearchViewModel @Inject constructor(
                 series = filteredSeries,
                 authors = filteredAuthors
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("SearchViewModel", "Search error", e)
             _results.value = SearchResults()

--- a/app/src/main/java/com/sappho/audiobooks/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/settings/SettingsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sappho.audiobooks.presentation.theme.*
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
@@ -29,16 +30,16 @@ fun SettingsScreen(
     onBackClick: () -> Unit,
     viewModel: UserSettingsViewModel = hiltViewModel()
 ) {
-    val isLoading by viewModel.isLoading.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
 
     // Playback settings
-    val skipForwardSeconds by viewModel.userPreferences.skipForwardSeconds.collectAsState()
-    val skipBackwardSeconds by viewModel.userPreferences.skipBackwardSeconds.collectAsState()
-    val defaultPlaybackSpeed by viewModel.userPreferences.defaultPlaybackSpeed.collectAsState()
-    val rewindOnResumeSeconds by viewModel.userPreferences.rewindOnResumeSeconds.collectAsState()
-    val defaultSleepTimerMinutes by viewModel.userPreferences.defaultSleepTimerMinutes.collectAsState()
-    val bufferSizeSeconds by viewModel.userPreferences.bufferSizeSeconds.collectAsState()
-    val showChapterProgress by viewModel.userPreferences.showChapterProgress.collectAsState()
+    val skipForwardSeconds by viewModel.userPreferences.skipForwardSeconds.collectAsStateWithLifecycle()
+    val skipBackwardSeconds by viewModel.userPreferences.skipBackwardSeconds.collectAsStateWithLifecycle()
+    val defaultPlaybackSpeed by viewModel.userPreferences.defaultPlaybackSpeed.collectAsStateWithLifecycle()
+    val rewindOnResumeSeconds by viewModel.userPreferences.rewindOnResumeSeconds.collectAsStateWithLifecycle()
+    val defaultSleepTimerMinutes by viewModel.userPreferences.defaultSleepTimerMinutes.collectAsStateWithLifecycle()
+    val bufferSizeSeconds by viewModel.userPreferences.bufferSizeSeconds.collectAsStateWithLifecycle()
+    val showChapterProgress by viewModel.userPreferences.showChapterProgress.collectAsStateWithLifecycle()
 
     // Handle system back button
     BackHandler { onBackClick() }

--- a/app/src/main/java/com/sappho/audiobooks/presentation/settings/UserSettingsViewModel.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/settings/UserSettingsViewModel.kt
@@ -9,6 +9,7 @@ import com.sappho.audiobooks.data.repository.AuthRepository
 import com.sappho.audiobooks.data.repository.UserPreferencesRepository
 import com.sappho.audiobooks.domain.model.User
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -49,6 +50,8 @@ class UserSettingsViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _user.value = response.body()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
             } finally {
                 _isLoading.value = false
@@ -63,6 +66,8 @@ class UserSettingsViewModel @Inject constructor(
                 if (response.isSuccessful) {
                     _serverVersion.value = response.body()?.version
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
             }
         }
@@ -79,6 +84,8 @@ class UserSettingsViewModel @Inject constructor(
                 } else {
                     _message.value = "Failed to update profile"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {
@@ -97,6 +104,8 @@ class UserSettingsViewModel @Inject constructor(
                 } else {
                     _message.value = response.errorBody()?.string() ?: "Failed to update password"
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _message.value = "Error: ${e.message}"
             } finally {

--- a/app/src/main/java/com/sappho/audiobooks/presentation/theme/AdaptiveLayout.kt
+++ b/app/src/main/java/com/sappho/audiobooks/presentation/theme/AdaptiveLayout.kt
@@ -222,13 +222,3 @@ fun shouldShowNavigationRail(): Boolean {
     return screenSize == ScreenSize.EXPANDED ||
            (screenSize == ScreenSize.MEDIUM && isLandscape())
 }
-
-/**
- * Determine if detail screen should use two-column layout
- */
-@Composable
-fun shouldUseTwoColumnDetail(): Boolean {
-    val screenSize = rememberScreenSize()
-    return screenSize == ScreenSize.EXPANDED ||
-           (screenSize == ScreenSize.MEDIUM && isLandscape())
-}

--- a/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/AudioPlaybackService.kt
@@ -120,9 +120,6 @@ class AudioPlaybackService : MediaLibraryService() {
         private const val CONTINUE_LISTENING_ID = "__CONTINUE_LISTENING__"
         private const val CHAPTERS_PREFIX = "__CHAPTERS__"
 
-        // Skip duration in seconds (hardcoded to 10 seconds)
-        const val SKIP_SECONDS = 10L
-
         // Minimum time (in seconds) before first progress sync
         // This prevents recording progress for accidental plays or quick skips
         private const val INITIAL_PROGRESS_DELAY_SECONDS = 20
@@ -930,37 +927,6 @@ class AudioPlaybackService : MediaLibraryService() {
         } catch (e: Exception) {
             android.util.Log.e("AutoService", "Exception during search", e)
             lastSearchResults = emptyList()
-        }
-    }
-
-    /**
-     * Search and auto-play the best matching audiobook.
-     * Used by voice search ("Hey Google, play X on Sappho").
-     */
-    private fun searchAndPlayAudiobook(query: String) {
-        if (query.isBlank()) return
-
-        serviceScope.launch {
-            try {
-                android.util.Log.d("AutoService", "Voice search - searching for: $query")
-                val response = api.getAudiobooks(search = query, limit = 5)
-                if (response.isSuccessful) {
-                    val audiobooks = response.body()?.audiobooks ?: emptyList()
-                    if (audiobooks.isNotEmpty()) {
-                        // Play the best match (first result)
-                        val audiobook = audiobooks.first()
-                        android.util.Log.d("AutoService", "Voice search - playing: ${audiobook.title}")
-                        val startPosition = audiobook.progress?.position ?: 0
-                        loadAndPlay(audiobook, startPosition)
-                    } else {
-                        android.util.Log.w("AutoService", "Voice search - no results for: $query")
-                    }
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                android.util.Log.e("AutoService", "Voice search error", e)
-            }
         }
     }
 

--- a/app/src/main/java/com/sappho/audiobooks/service/PlayerState.kt
+++ b/app/src/main/java/com/sappho/audiobooks/service/PlayerState.kt
@@ -104,18 +104,4 @@ class PlayerState @Inject constructor() {
         _bufferedPosition.value = 0L
         _lastActiveTimestamp.value = 0L
     }
-
-    fun clear() {
-        _currentAudiobook.value = null
-        _isPlaying.value = false
-        _currentPosition.value = 0L
-        _duration.value = 0L
-        _isLoading.value = false
-        _playbackSpeed.value = 1.0f
-        _sleepTimerRemaining.value = null
-        _sleepAtEndOfChapter.value = false
-        _bufferedPosition.value = 0L
-        _lastActiveTimestamp.value = 0L
-        _playbackError.value = null
-    }
 }

--- a/app/src/main/java/com/sappho/audiobooks/util/ApiErrorParser.kt
+++ b/app/src/main/java/com/sappho/audiobooks/util/ApiErrorParser.kt
@@ -1,0 +1,25 @@
+package com.sappho.audiobooks.util
+
+import com.google.gson.JsonParser
+import retrofit2.Response
+
+/**
+ * Extract a human-readable error message from a JSON error body of the form
+ * `{"error": "..."}` or `{"message": "..."}`.
+ *
+ * Returns null if the body is missing, blank, or not parseable as a JSON
+ * object with one of those fields.
+ */
+fun parseApiErrorMessage(response: Response<*>): String? =
+    try {
+        val body = response.errorBody()?.string()
+        if (body.isNullOrBlank()) {
+            null
+        } else {
+            val json = JsonParser.parseString(body).asJsonObject
+            json.get("error")?.takeIf { it.isJsonPrimitive }?.asString
+                ?: json.get("message")?.takeIf { it.isJsonPrimitive }?.asString
+        }
+    } catch (e: Exception) {
+        null
+    }

--- a/app/src/main/java/com/sappho/audiobooks/util/NetworkMonitor.kt
+++ b/app/src/main/java/com/sappho/audiobooks/util/NetworkMonitor.kt
@@ -25,10 +25,8 @@ class NetworkMonitor @Inject constructor(
 
     private val networkCallback = object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
-            Log.d(TAG, "Network available - triggering sync")
+            Log.d(TAG, "Network available")
             _isOnline.value = true
-            // Trigger progress sync when network becomes available
-            triggerProgressSync()
         }
 
         override fun onLost(network: Network) {
@@ -46,19 +44,8 @@ class NetworkMonitor @Inject constructor(
             val hasInternet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
                     capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
             Log.d(TAG, "Network capabilities changed, hasInternet: $hasInternet")
-            val wasOnline = _isOnline.value
             _isOnline.value = hasInternet
-            
-            // Trigger sync if we just came online
-            if (hasInternet && !wasOnline) {
-                triggerProgressSync()
-            }
         }
-    }
-    
-    private fun triggerProgressSync() {
-        // This will be injected with SyncStatusManager in a more complete implementation
-        Log.d(TAG, "Network available - would trigger progress sync")
     }
 
     init {

--- a/app/src/main/java/com/sappho/audiobooks/util/PerformanceMonitor.kt
+++ b/app/src/main/java/com/sappho/audiobooks/util/PerformanceMonitor.kt
@@ -2,13 +2,7 @@ package com.sappho.audiobooks.util
 
 import android.os.Debug
 import android.util.Log
-import androidx.compose.runtime.*
 import com.sappho.audiobooks.BuildConfig
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -20,32 +14,12 @@ class PerformanceMonitor @Inject constructor() {
         val isEnabled = BuildConfig.DEBUG
     }
 
-    private val monitorScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private var memoryMonitorJob: Job? = null
-
     /**
      * Measure execution time of a suspend function
      */
     suspend inline fun <T> measureTime(
         operation: String,
         crossinline block: suspend () -> T
-    ): T {
-        if (!isEnabled) return block()
-
-        val startTime = System.currentTimeMillis()
-        val result = block()
-        val endTime = System.currentTimeMillis()
-
-        Log.d(TAG, "$operation took ${endTime - startTime}ms")
-        return result
-    }
-
-    /**
-     * Measure execution time of a regular function
-     */
-    inline fun <T> measureTimeSync(
-        operation: String,
-        crossinline block: () -> T
     ): T {
         if (!isEnabled) return block()
 
@@ -69,54 +43,5 @@ class PerformanceMonitor @Inject constructor() {
         val nativeHeap = Debug.getNativeHeapAllocatedSize() / (1024 * 1024)
 
         Log.d(TAG, "$context - Memory: ${usedMemory}MB / ${maxMemory}MB, Native: ${nativeHeap}MB")
-    }
-
-    /**
-     * Start monitoring memory usage in background.
-     * Uses a stored scope with SupervisorJob for proper cancellation.
-     */
-    fun startMemoryMonitoring() {
-        if (!isEnabled) return
-
-        memoryMonitorJob?.cancel()
-        memoryMonitorJob = monitorScope.launch {
-            while (true) {
-                logMemoryUsage("Background Monitor")
-                kotlinx.coroutines.delay(30_000) // Log every 30 seconds
-            }
-        }
-    }
-
-    /**
-     * Stop the background memory monitoring.
-     */
-    fun stopMemoryMonitoring() {
-        memoryMonitorJob?.cancel()
-        memoryMonitorJob = null
-    }
-}
-
-/**
- * Composable for monitoring composition performance
- */
-@Composable
-fun PerformanceTracker(name: String) {
-    if (!BuildConfig.DEBUG) return
-
-    val recompositionCount = remember { mutableIntStateOf(0) }
-    val startTime = remember { System.currentTimeMillis() }
-
-    LaunchedEffect(Unit) {
-        Log.d("CompositionPerf", "$name: Initial composition")
-    }
-
-    SideEffect {
-        recompositionCount.intValue++
-        val currentTime = System.currentTimeMillis()
-        val timeSinceStart = currentTime - startTime
-
-        if (recompositionCount.intValue > 1) {
-            Log.d("CompositionPerf", "$name: Recomposition #${recompositionCount.intValue} at ${timeSinceStart}ms")
-        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Sappho</string>
-    <string name="notification_channel_name">Playback</string>
-    <string name="notification_channel_description">Audiobook playback controls</string>
 </resources>

--- a/app/src/test/java/com/sappho/audiobooks/di/NetworkModuleTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/di/NetworkModuleTest.kt
@@ -1,6 +1,7 @@
 package com.sappho.audiobooks.di
 
 import com.google.common.truth.Truth.assertThat
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Test
 
 class NetworkModuleTest {
@@ -100,5 +101,94 @@ class NetworkModuleTest {
         val result = NetworkModule.sanitizeBaseUrl("https://example.com:8443/a/b/c?x=1")
 
         assertThat(result).isEqualTo("https://example.com:8443/")
+    }
+
+    // --- rewriteUrlForServer (subpath deployments must not double-append the path) ---
+
+    @Test
+    fun `should rewrite retrofit-relative request onto subpath server url`() {
+        // Given: Retrofit's baseUrl is sanitized to scheme+host, so its request
+        // paths never include the subpath
+        val original = "https://example.com/api/audiobooks/meta/recent".toHttpUrl()
+
+        // When
+        val result = NetworkModule.rewriteUrlForServer(original, "https://example.com/sappho")
+
+        // Then
+        assertThat(result.toString())
+            .isEqualTo("https://example.com/sappho/api/audiobooks/meta/recent")
+    }
+
+    @Test
+    fun `should not double-append subpath for absolute url already containing it`() {
+        // Given: cover URLs are built as "$serverUrl/api/audiobooks/{id}/cover",
+        // so with a subpath deployment the path already starts with the subpath
+        val original = "https://example.com/sappho/api/audiobooks/5/cover".toHttpUrl()
+
+        // When
+        val result = NetworkModule.rewriteUrlForServer(original, "https://example.com/sappho")
+
+        // Then: previously produced ".../sappho/sappho/api/..."
+        assertThat(result.toString())
+            .isEqualTo("https://example.com/sappho/api/audiobooks/5/cover")
+    }
+
+    @Test
+    fun `should not strip path segment that merely shares the subpath as a text prefix`() {
+        // Given: "/sapphoapi" is not the "/sappho" subpath even though it starts
+        // with the same characters
+        val original = "https://example.com/sapphoapi/covers/5".toHttpUrl()
+
+        // When
+        val result = NetworkModule.rewriteUrlForServer(original, "https://example.com/sappho")
+
+        // Then
+        assertThat(result.toString())
+            .isEqualTo("https://example.com/sappho/sapphoapi/covers/5")
+    }
+
+    @Test
+    fun `should rewrite host and preserve query parameters`() {
+        // Given: a request built against an old host with a query string
+        val original = "http://192.168.1.100:3002/api/audiobooks/5/stream?token=abc".toHttpUrl()
+
+        // When
+        val result = NetworkModule.rewriteUrlForServer(original, "https://example.com")
+
+        // Then
+        assertThat(result.toString())
+            .isEqualTo("https://example.com/api/audiobooks/5/stream?token=abc")
+    }
+
+    @Test
+    fun `should append full path when hosts differ even with matching prefix`() {
+        // Given: prefix-stripping only applies to requests targeting the server
+        // host — other hosts keep their full path
+        val original = "http://192.168.1.100:3002/sappho/api/audiobooks/5/cover".toHttpUrl()
+
+        // When
+        val result = NetworkModule.rewriteUrlForServer(original, "https://example.com/sappho")
+
+        // Then
+        assertThat(result.toString())
+            .isEqualTo("https://example.com/sappho/sappho/api/audiobooks/5/cover")
+    }
+
+    @Test
+    fun `should return null for unparseable server url`() {
+        val original = "https://example.com/api/audiobooks/5/cover".toHttpUrl()
+
+        val result = NetworkModule.rewriteUrlForServer(original, "not a url")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `should rewrite unchanged for server url without subpath`() {
+        val original = "https://example.com/api/audiobooks/5/cover".toHttpUrl()
+
+        val result = NetworkModule.rewriteUrlForServer(original, "https://example.com")
+
+        assertThat(result.toString()).isEqualTo("https://example.com/api/audiobooks/5/cover")
     }
 }

--- a/app/src/test/java/com/sappho/audiobooks/download/DownloadManagerTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/download/DownloadManagerTest.kt
@@ -2,15 +2,11 @@ package com.sappho.audiobooks.download
 
 import android.content.Context
 import com.google.common.truth.Truth.assertThat
-import com.sappho.audiobooks.data.remote.SapphoApi
-import com.sappho.audiobooks.data.repository.AuthRepository
 import com.sappho.audiobooks.domain.model.Audiobook
 import com.sappho.audiobooks.domain.model.Chapter
 import com.sappho.audiobooks.domain.model.Progress
-import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -21,8 +17,6 @@ class DownloadManagerTest {
 
     private lateinit var downloadManager: DownloadManager
     private val context = mockk<Context>(relaxed = true)
-    private val authRepository = mockk<AuthRepository>()
-    private val api = mockk<SapphoApi>()
     private val testDispatcher = StandardTestDispatcher()
 
     @Before
@@ -34,7 +28,7 @@ class DownloadManagerTest {
         }
         every { context.filesDir } returns filesDir
 
-        downloadManager = DownloadManager(context, authRepository, api)
+        downloadManager = DownloadManager(context)
     }
 
     @Test

--- a/app/src/test/java/com/sappho/audiobooks/presentation/components/BookCollectionsControllerTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/presentation/components/BookCollectionsControllerTest.kt
@@ -1,0 +1,160 @@
+package com.sappho.audiobooks.presentation.components
+
+import com.google.common.truth.Truth.assertThat
+import com.sappho.audiobooks.data.remote.AddToCollectionRequest
+import com.sappho.audiobooks.data.remote.Collection
+import com.sappho.audiobooks.data.remote.CollectionForBook
+import com.sappho.audiobooks.data.remote.SapphoApi
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Test
+import retrofit2.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BookCollectionsControllerTest {
+
+    private val api: SapphoApi = mockk()
+
+    private fun collection(id: Int, name: String = "Collection $id") = Collection(
+        id = id,
+        name = name,
+        description = null,
+        userId = 1,
+        bookCount = 0,
+        firstCover = null,
+        bookIds = null,
+        isPublic = 0,
+        isOwner = 1,
+        creatorUsername = null,
+        createdAt = null,
+        updatedAt = null
+    )
+
+    private fun errorResponse(): Response<Unit> = Response.error(
+        500,
+        "{\"error\":\"boom\"}".toResponseBody("application/json".toMediaType())
+    )
+
+    @Test
+    fun `should load collections and membership for book`() = runTest {
+        // Given
+        val controller = BookCollectionsController(api, this, "Test")
+        coEvery { api.getCollections() } returns Response.success(listOf(collection(1), collection(2)))
+        coEvery { api.getCollectionsForBook(42) } returns Response.success(
+            listOf(
+                CollectionForBook(id = 1, name = "Collection 1", containsBook = 1),
+                CollectionForBook(id = 2, name = "Collection 2", containsBook = 0)
+            )
+        )
+
+        // When
+        controller.loadCollectionsForBook(42)
+        advanceUntilIdle()
+
+        // Then
+        assertThat(controller.collections.value.map { it.id }).containsExactly(1, 2)
+        assertThat(controller.bookCollections.value).containsExactly(1)
+        assertThat(controller.isLoadingCollections.value).isFalse()
+    }
+
+    @Test
+    fun `should clear loading flag when load fails`() = runTest {
+        // Given
+        val controller = BookCollectionsController(api, this, "Test")
+        coEvery { api.getCollections() } throws RuntimeException("network down")
+
+        // When
+        controller.loadCollectionsForBook(42)
+        advanceUntilIdle()
+
+        // Then
+        assertThat(controller.isLoadingCollections.value).isFalse()
+        assertThat(controller.collections.value).isEmpty()
+    }
+
+    @Test
+    fun `should add book to collection when not a member`() = runTest {
+        // Given
+        val controller = BookCollectionsController(api, this, "Test")
+        coEvery { api.addToCollection(5, AddToCollectionRequest(42)) } returns
+            Response.success(Unit)
+
+        // When
+        controller.toggleBookInCollection(5, 42)
+        advanceUntilIdle()
+
+        // Then
+        assertThat(controller.bookCollections.value).containsExactly(5)
+        coVerify(exactly = 1) { api.addToCollection(5, AddToCollectionRequest(42)) }
+    }
+
+    @Test
+    fun `should remove book from collection when already a member`() = runTest {
+        // Given - make book a member of collection 5 first
+        val controller = BookCollectionsController(api, this, "Test")
+        coEvery { api.addToCollection(5, AddToCollectionRequest(42)) } returns Response.success(Unit)
+        controller.toggleBookInCollection(5, 42)
+        advanceUntilIdle()
+        coEvery { api.removeFromCollection(5, 42) } returns Response.success(Unit)
+
+        // When
+        controller.toggleBookInCollection(5, 42)
+        advanceUntilIdle()
+
+        // Then
+        assertThat(controller.bookCollections.value).isEmpty()
+        coVerify(exactly = 1) { api.removeFromCollection(5, 42) }
+    }
+
+    @Test
+    fun `should not update membership when toggle request fails`() = runTest {
+        // Given
+        val controller = BookCollectionsController(api, this, "Test")
+        coEvery { api.addToCollection(5, AddToCollectionRequest(42)) } returns errorResponse()
+
+        // When
+        controller.toggleBookInCollection(5, 42)
+        advanceUntilIdle()
+
+        // Then
+        assertThat(controller.bookCollections.value).isEmpty()
+    }
+
+    @Test
+    fun `should create collection and add book to it`() = runTest {
+        // Given
+        val controller = BookCollectionsController(api, this, "Test")
+        val created = collection(9, "New Collection")
+        coEvery { api.createCollection(any()) } returns Response.success(created)
+        coEvery { api.addToCollection(9, AddToCollectionRequest(42)) } returns Response.success(Unit)
+
+        // When
+        controller.createCollectionAndAddBook("New Collection", 42)
+        advanceUntilIdle()
+
+        // Then
+        assertThat(controller.collections.value.first().id).isEqualTo(9)
+        assertThat(controller.bookCollections.value).containsExactly(9)
+    }
+
+    @Test
+    fun `should leave state unchanged when create collection fails`() = runTest {
+        // Given
+        val controller = BookCollectionsController(api, this, "Test")
+        coEvery { api.createCollection(any()) } throws RuntimeException("boom")
+
+        // When
+        controller.createCollectionAndAddBook("New Collection", 42)
+        advanceUntilIdle()
+
+        // Then
+        assertThat(controller.collections.value).isEmpty()
+        assertThat(controller.bookCollections.value).isEmpty()
+    }
+}

--- a/app/src/test/java/com/sappho/audiobooks/util/ApiErrorParserTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/util/ApiErrorParserTest.kt
@@ -1,0 +1,66 @@
+package com.sappho.audiobooks.util
+
+import com.google.common.truth.Truth.assertThat
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Test
+import retrofit2.Response
+
+class ApiErrorParserTest {
+
+    private fun errorResponse(body: String): Response<Unit> = Response.error(
+        500,
+        body.toResponseBody("application/json".toMediaType())
+    )
+
+    @Test
+    fun `should parse error field from json body`() {
+        val result = parseApiErrorMessage(errorResponse("{\"error\":\"Something broke\"}"))
+
+        assertThat(result).isEqualTo("Something broke")
+    }
+
+    @Test
+    fun `should fall back to message field when error field missing`() {
+        val result = parseApiErrorMessage(errorResponse("{\"message\":\"Not found\"}"))
+
+        assertThat(result).isEqualTo("Not found")
+    }
+
+    @Test
+    fun `should prefer error field over message field`() {
+        val result = parseApiErrorMessage(
+            errorResponse("{\"error\":\"primary\",\"message\":\"secondary\"}")
+        )
+
+        assertThat(result).isEqualTo("primary")
+    }
+
+    @Test
+    fun `should return null for non-json body`() {
+        val result = parseApiErrorMessage(errorResponse("Internal Server Error"))
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `should return null for empty body`() {
+        val result = parseApiErrorMessage(errorResponse(""))
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `should return null when fields are not string primitives`() {
+        val result = parseApiErrorMessage(errorResponse("{\"error\":{\"code\":1}}"))
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `should return null for successful response without error body`() {
+        val result = parseApiErrorMessage(Response.success(Unit))
+
+        assertThat(result).isNull()
+    }
+}

--- a/app/src/test/java/com/sappho/audiobooks/util/PerformanceMonitorTest.kt
+++ b/app/src/test/java/com/sappho/audiobooks/util/PerformanceMonitorTest.kt
@@ -33,36 +33,10 @@ class PerformanceMonitorTest {
     }
 
     @Test
-    fun `should measure time for sync function`() = runTest {
-        // Given
-        var executed = false
-
-        // When
-        val result = performanceMonitor.measureTimeSync("test sync operation") {
-            Thread.sleep(10) // Simulate some work
-            executed = true
-            "sync result"
-        }
-
-        // Then
-        assertThat(result).isEqualTo("sync result")
-        assertThat(executed).isTrue()
-    }
-
-    @Test
     fun `should log memory usage without crashing`() {
         // When/Then - Should not throw any exceptions
         performanceMonitor.logMemoryUsage("test context")
-        
-        // Test passes if no exception is thrown
-        assertThat(true).isTrue()
-    }
 
-    @Test
-    fun `should start memory monitoring without crashing`() {
-        // When/Then - Should not throw any exceptions
-        performanceMonitor.startMemoryMonitoring()
-        
         // Test passes if no exception is thrown
         assertThat(true).isTrue()
     }


### PR DESCRIPTION
## Summary

Third PR from the deep audit. 53 files, +1144/−820.

### Dependencies removed
- Room (runtime/ktx/compiler), kotlinx-serialization (+ retrofit converter + plugin), all three accompanist libs
- AdminScreen's 6 SwipeRefresh usages migrated to Material3 `PullToRefreshBox`

### Dead code deleted
- `DownloadManager.downloadAudiobook` legacy pipeline (+ now-unused `downloadClient`, `api`, `authRepository` deps) — DownloadService is the sole download path
- `localNetwork` OkHttp client, `searchAndPlayAudiobook`, `SKIP_SECONDS`, unused PerformanceMonitor members, `shouldUseTwoColumnDetail`, `triggerProgressSync` stub, `PlayerState.clear()`, unused notification strings

### Correctness
- **CancellationException rethrow sweep**: 154 insertions across 18 remaining files (ViewModels, cast stack, discovery, InAppUpdateManager) — structured concurrency no longer swallowed by generic catches
- **Subpath double-append fix**: new `rewriteUrlForServer()` in NetworkModule — cover URLs on subpath deployments (e.g. `https://host/sappho`) no longer get the prefix appended twice; 7 new tests incl. repro + `/sapphoapi` boundary guard
- `downloadManager` made private on MainViewModel/AudiobookDetailViewModel with narrow flows exposed

### Refactors
- All 188 `collectAsState()` → `collectAsStateWithLifecycle()`
- Extracted `BookCollectionsController` (dedups collection-picker logic in Home/Detail VMs) + `parseApiErrorMessage()` util — 14 new tests

### Deferred (still-open audit items)
- M2 notification consolidation (legacy notification is load-bearing for pause-timeout foregrounding), M5 MediaController migration, L4 ViewModel split

## Version
- versionCode 104, versionName 0.9.86

## Testing
- 218 unit tests pass, assembleDebug + lintDebug clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)